### PR TITLE
Keystore loading - make UUID and path optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 #Changelog
 
+## Next Release
+### Features Added
+- BLS keystore file (EIP-2335) parsing - make path and UUID fields optional
+
+### Bugs fixes
+- NA
+ 
 ## 1.10.12
 ### Features Added
 - Change Interlock keystore API fetchKey argument type

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KeyStoreData.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KeyStoreData.java
@@ -38,18 +38,18 @@ public class KeyStoreData {
   public KeyStoreData(
       @JsonProperty(value = "crypto", required = true) final Crypto crypto,
       @JsonProperty(value = "pubkey", required = true) final Bytes pubkey,
-      @JsonProperty(value = "path", required = true) final String path,
-      @JsonProperty(value = "uuid", required = true) final UUID uuid,
-      @JsonProperty(value = "version", required = true) final Integer version) {
+      @JsonProperty(value = "version", required = true) final Integer version,
+      @JsonProperty(value = "path", required = false) final String path,
+      @JsonProperty(value = "uuid", required = false) final UUID uuid) {
     this.crypto = crypto;
     this.pubkey = pubkey;
+    this.version = version;
     this.path = path;
     this.uuid = uuid;
-    this.version = version;
   }
 
   public KeyStoreData(final Crypto crypto, final Bytes pubkey, final String path) {
-    this(crypto, pubkey, path, UUID.randomUUID(), KEYSTORE_VERSION);
+    this(crypto, pubkey, KEYSTORE_VERSION, path, UUID.randomUUID());
   }
 
   public Crypto getCrypto() {

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KeyStoreData.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KeyStoreData.java
@@ -17,6 +17,7 @@ import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes;
@@ -26,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes;
  *
  * @see <a href="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2335.md">EIP-2335</a>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class KeyStoreData {
   public static final int KEYSTORE_VERSION = 4;
   private final Crypto crypto;
@@ -39,8 +41,8 @@ public class KeyStoreData {
       @JsonProperty(value = "crypto", required = true) final Crypto crypto,
       @JsonProperty(value = "pubkey", required = true) final Bytes pubkey,
       @JsonProperty(value = "version", required = true) final Integer version,
-      @JsonProperty(value = "path", required = false) final String path,
-      @JsonProperty(value = "uuid", required = false) final UUID uuid) {
+      @JsonProperty(value = "path") final String path,
+      @JsonProperty(value = "uuid") final UUID uuid) {
     this.crypto = crypto;
     this.pubkey = pubkey;
     this.version = version;

--- a/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
+++ b/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
@@ -58,6 +58,8 @@ class KeyStoreTest {
   private static final String SCRYPT_KEYSTORE_RESOURCE = "scryptTestVector.json";
   private static final String SCRYPT_EXTRA_FIELD_KEYSTORE_RESOURCE =
       "scryptExtraFieldTestVector.json";
+  private static final String SCRYPT_MISSING_UUID_PATH_KEYSTORE_RESOURCE =
+      "scryptTestVectorWithMissingPathAndUUID.json";
   private static final String PBKDF2_KEYSTORE_RESOURCE = "pbkdf2TestVector.json";
   private static final String MISSING_SECTION_KEYSTORE_RESOURCE =
       "missingKdfSectionTestVector.json";
@@ -94,6 +96,11 @@ class KeyStoreTest {
   @Test
   void ableToLoadKeystoreWithUnknownFieldsAndDecryptKey() {
     loadKeyStoreAndDecryptKey(SCRYPT_EXTRA_FIELD_KEYSTORE_RESOURCE);
+  }
+
+  @Test
+  void ableToLoadKeystoreWithMissingUUIDAndPathFieldsAndDecryptKey() {
+    loadKeyStoreAndDecryptKey(SCRYPT_MISSING_UUID_PATH_KEYSTORE_RESOURCE);
   }
 
   @Test

--- a/bls-keystore/src/test/resources/scryptTestVectorWithMissingPathAndUUID.json
+++ b/bls-keystore/src/test/resources/scryptTestVectorWithMissingPathAndUUID.json
@@ -1,0 +1,30 @@
+{
+  "crypto": {
+    "kdf": {
+      "function": "scrypt",
+      "params": {
+        "dklen": 32,
+        "n": 262144,
+        "p": 1,
+        "r": 8,
+        "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+      },
+      "message": ""
+    },
+    "checksum": {
+      "function": "sha256",
+      "params": {},
+      "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
+    },
+    "cipher": {
+      "function": "aes-128-ctr",
+      "params": {
+        "iv": "264daa3f303d7259501c93d997d84fe6"
+      },
+      "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
+    }
+  },
+  "description": "This is a test keystore that uses scrypt to secure the secret.",
+  "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+  "version": 4
+}


### PR DESCRIPTION
 -- UUID and path are not used during decryption
 -- some other implementations don't generate them. This change make those keystores compatible.

Signed-off-by: Usman Saleem <usman@usmans.info>