### PR TITLE
Update Azure Key Vault Signer signing algorithm

### DIFF
--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
@@ -44,7 +44,7 @@ public class AzureKeyVaultSigner implements Signer {
   private final AzureConfig config;
   private final ECPublicKey publicKey;
   private final SignatureAlgorithm signingAlgo = SignatureAlgorithm.ES256K;
-  private final boolean needsToHash;
+  private final boolean needsToHash; // Apply Hash.sha3(data) before signing
 
   public AzureKeyVaultSigner(
       final AzureConfig config, final Bytes publicKey, final boolean needsToHash) {

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
@@ -43,7 +43,7 @@ public class AzureKeyVaultSigner implements Signer {
 
   private final AzureConfig config;
   private final ECPublicKey publicKey;
-  private final SignatureAlgorithm signingAlgo = SignatureAlgorithm.fromString("ECDSA256");
+  private final SignatureAlgorithm signingAlgo = SignatureAlgorithm.ES256K;
   private final boolean needsToHash;
 
   public AzureKeyVaultSigner(

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
@@ -43,14 +43,21 @@ public class AzureKeyVaultSigner implements Signer {
 
   private final AzureConfig config;
   private final ECPublicKey publicKey;
-  private final SignatureAlgorithm signingAlgo = SignatureAlgorithm.ES256K;
+  private final SignatureAlgorithm signingAlgo;
   private final boolean needsToHash; // Apply Hash.sha3(data) before signing
 
-  public AzureKeyVaultSigner(
-      final AzureConfig config, final Bytes publicKey, final boolean needsToHash) {
+  AzureKeyVaultSigner(
+      final AzureConfig config,
+      final Bytes publicKey,
+      final boolean needsToHash,
+      final boolean useDeprecatedSignatureAlgorithm) {
     this.config = config;
     this.publicKey = EthPublicKeyUtils.createPublicKey(publicKey);
     this.needsToHash = needsToHash;
+    this.signingAlgo =
+        useDeprecatedSignatureAlgorithm
+            ? SignatureAlgorithm.fromString("ECDSA256")
+            : SignatureAlgorithm.ES256K;
   }
 
   @Override

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerFactory.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerFactory.java
@@ -19,6 +19,8 @@ import tech.pegasys.signers.azure.AzureKeyVault;
 import tech.pegasys.signers.secp256k1.api.Signer;
 import tech.pegasys.signers.secp256k1.common.SignerInitializationException;
 
+import java.util.Set;
+
 import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
 import com.azure.security.keyvault.keys.models.JsonWebKey;
 import org.apache.logging.log4j.LogManager;
@@ -30,7 +32,9 @@ public class AzureKeyVaultSignerFactory {
   public static final String INACCESSIBLE_KEY_ERROR = "Failed to authenticate to vault.";
   public static final String INVALID_KEY_PARAMETERS_ERROR =
       "Keyvault does not contain key with specified parameters";
-  public static final String INVALID_CURVE_NAME = "Remote key has invalid curve name";
+  public static final String UNSUPPORTED_CURVE_NAME = "Remote key has unsupported curve name";
+  private static final String DEPRECATED_CURVE_NAME = "SECP256K1";
+  private static final Set<String> SUPPORTED_CURVE_NAMES = Set.of(DEPRECATED_CURVE_NAME, "P-256K");
   private static final Logger LOG = LogManager.getLogger();
 
   private final boolean needsToHash;
@@ -68,13 +72,14 @@ public class AzureKeyVaultSignerFactory {
     }
     final JsonWebKey jsonWebKey = cryptoClient.getKey().getKey();
     final String curveName = jsonWebKey.getCurveName().toString();
-    if (!curveName.equals("SECP256K1") && !curveName.equals("P-256K")) {
-      LOG.error("Unsupported curve name: {}. Expecting P-256K", curveName);
-      throw new SignerInitializationException(INVALID_CURVE_NAME);
+    if (!SUPPORTED_CURVE_NAMES.contains(curveName)) {
+      LOG.error(
+          "Unsupported curve name: {}. Expecting one of {}.", curveName, SUPPORTED_CURVE_NAMES);
+      throw new SignerInitializationException(UNSUPPORTED_CURVE_NAME);
     }
     final Bytes rawPublicKey =
         Bytes.concatenate(Bytes.wrap(jsonWebKey.getX()), Bytes.wrap(jsonWebKey.getY()));
-    return new AzureKeyVaultSigner(
-        config, rawPublicKey, needsToHash, curveName.equals("SECP256K1"));
+    final boolean useDeprecatedCurveName = DEPRECATED_CURVE_NAME.equals(curveName);
+    return new AzureKeyVaultSigner(config, rawPublicKey, needsToHash, useDeprecatedCurveName);
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -18,10 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
+import tech.pegasys.signers.secp256k1.common.SignerInitializationException;
 
 import java.math.BigInteger;
 import java.security.SignatureException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,7 @@ public class AzureKeyVaultSignerTest {
   private static final String KEY_NAME = "TestKey2";
   // uses deprecated curve name SECP256K1
   private static final String DEPRECATED_KEY_NAME = "TestKey";
+  private static final String UNSUPPORTED_CURVE_KEY_NAME = "TestKeyP521";
 
   @BeforeAll
   static void preChecks() {
@@ -89,5 +92,16 @@ public class AzureKeyVaultSignerTest {
 
     final BigInteger recoveredPublicKey = Sign.signedMessageHashToKey(hashedData, sigData);
     assertThat(recoveredPublicKey).isEqualTo(publicKey);
+  }
+
+  @Test
+  public void azureKeyWithUnsupportedCurveThrowsError() {
+    final AzureConfig config =
+        new AzureConfig(
+            keyVaultName, UNSUPPORTED_CURVE_KEY_NAME, "", clientId, clientSecret, tenantId);
+
+    final AzureKeyVaultSignerFactory factory = new AzureKeyVaultSignerFactory();
+    Assertions.assertThatExceptionOfType(SignerInitializationException.class)
+        .isThrownBy(() -> factory.createSigner(config));
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -14,6 +14,7 @@ package tech.pegasys.signers.secp256k1.azure;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory.INVALID_CURVE_NAME;
 
 import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.signers.secp256k1.api.Signature;
@@ -35,7 +36,6 @@ import org.web3j.crypto.Sign.SignatureData;
 import org.web3j.utils.Numeric;
 
 public class AzureKeyVaultSignerTest {
-
   private static final String clientId = System.getenv("AZURE_CLIENT_ID");
   private static final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
   private static final String keyVaultName = System.getenv("AZURE_KEY_VAULT_NAME");
@@ -102,6 +102,7 @@ public class AzureKeyVaultSignerTest {
 
     final AzureKeyVaultSignerFactory factory = new AzureKeyVaultSignerFactory();
     Assertions.assertThatExceptionOfType(SignerInitializationException.class)
-        .isThrownBy(() -> factory.createSigner(config));
+        .isThrownBy(() -> factory.createSigner(config))
+        .withMessage(INVALID_CURVE_NAME);
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -38,8 +38,9 @@ public class AzureKeyVaultSignerTest {
   private static final String tenantId = System.getenv("AZURE_TENANT_ID");
 
   public static final String PUBLIC_KEY_HEX_STRING =
-      "09b02f8a5fddd222ade4ea4528faefc399623af3f736be3c44f03e2df22fb792f3931a4d9573d333ca74343305762a753388c3422a86d98b713fc91c1ea04842";
+      "964f00253459f1f43c7a7720a0db09a328d4ee6f18838015023135d7fc921f1448de34d05de7a1f72a7b5c9f6c76931d7ab33d0f0846ccce5452063bd20f5809";
   private final Bytes publicKeyBytes = Bytes.fromHexString(PUBLIC_KEY_HEX_STRING);
+  private static final String KEY_NAME = "TestKey2";
 
   @BeforeAll
   static void preChecks() {
@@ -51,7 +52,7 @@ public class AzureKeyVaultSignerTest {
   @Test
   public void azureSignerCanSignTwice() {
     final AzureConfig config =
-        new AzureConfig(keyVaultName, "TestKey", "", clientId, clientSecret, tenantId);
+        new AzureConfig(keyVaultName, KEY_NAME, "", clientId, clientSecret, tenantId);
 
     final AzureKeyVaultSignerFactory factory = new AzureKeyVaultSignerFactory();
     final Signer signer = factory.createSigner(config);
@@ -64,7 +65,7 @@ public class AzureKeyVaultSignerTest {
   @Test
   void azureWithoutHashingDoesntHashData() throws SignatureException {
     final AzureConfig config =
-        new AzureConfig(keyVaultName, "TestKey", "", clientId, clientSecret, tenantId);
+        new AzureConfig(keyVaultName, KEY_NAME, "", clientId, clientSecret, tenantId);
 
     final AzureKeyVaultSigner nonHashingSigner =
         new AzureKeyVaultSigner(config, publicKeyBytes, false);

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.signers.secp256k1.azure;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory.INVALID_CURVE_NAME;
+import static tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory.UNSUPPORTED_CURVE_NAME;
 
 import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.signers.secp256k1.api.Signature;
@@ -103,6 +103,6 @@ public class AzureKeyVaultSignerTest {
     final AzureKeyVaultSignerFactory factory = new AzureKeyVaultSignerFactory();
     Assertions.assertThatExceptionOfType(SignerInitializationException.class)
         .isThrownBy(() -> factory.createSigner(config))
-        .withMessage(INVALID_CURVE_NAME);
+        .withMessage(UNSUPPORTED_CURVE_NAME);
   }
 }


### PR DESCRIPTION
* Azure has deprecated curve name `SECP256K1`, instead they now use curve name `P-256K` when creating new keys or updating expired keys. 
* `ECDSA256` signature algorithm name has been deprecated. ES256K is to be used with `P-256K`.
