### PR TITLE
Fix dependency issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat
 
 plugins {
   id 'java-test-fixtures'
-  id 'com.diffplug.gradle.spotless' version '3.27.1'
+  id "com.diffplug.spotless" version "5.15.0"
   id 'com.github.ben-manes.versions' version '0.27.0'
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
@@ -103,15 +103,13 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
-    jcenter()
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
-    maven { url  "https://consensys.bintray.com/pegasys-repo" }
   }
 
   dependencies { errorprone("com.google.errorprone:error_prone_core") }
 
-  apply plugin: 'com.diffplug.gradle.spotless'
+  apply plugin: 'com.diffplug.spotless'
   spotless {
     java {
       // This path needs to be relative to each project

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat
 
 plugins {
   id 'java-test-fixtures'
-  id "com.diffplug.spotless" version "5.15.0"
+  id 'com.diffplug.spotless' version '5.15.0'
   id 'com.github.ben-manes.versions' version '0.27.0'
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.2.0'
 
-    dependencySet(group: 'io.vertx', version: '3.9.8') {
+    dependencySet(group: 'io.vertx', version: '3.9.9') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,11 +29,13 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.2.0'
 
-    dependency 'io.vertx:vertx-codegen:3.8.2'
-    dependency 'io.vertx:vertx-core:3.8.2'
-    dependency 'io.vertx:vertx-unit:3.8.2'
-    dependency 'io.vertx:vertx-web-client:3.8.2'
-    dependency 'io.vertx:vertx-web:3.8.2'
+    dependencySet(group: 'io.vertx', version: '3.9.8') {
+      entry 'vertx-codegen'
+      entry 'vertx-core'
+      entry 'vertx-unit'
+      entry 'vertx-web-client'
+      entry 'vertx-web'
+    }
 
     dependency 'javax.activation:activation:1.1.1'
 


### PR DESCRIPTION
jcenter/bintray is now defunct so removing repository references as it caused a build error.
Upgraded spotless and brought vertx versions inline with web3signer