### PR TITLE
Upgrade to Azure Key Vault 4.3.3 following vertx upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #Changelog
 
+## 1.0.18
+### Breaking Changes
+- Upgrade to Azure Key Vault 4.3.3 removes support for previously deprecated SECP256K1 curve.
+
 ## 1.0.17
 ### Features Added
 - Azure remote signing - add support for keys using curve name P-256K and signature algorithm name ES256K. Curve name 

--- a/acceptance-tests/src/testFixtures/java/tech.pegasys.signers.secp256k1/MultiKeyTomlFileUtil.java
+++ b/acceptance-tests/src/testFixtures/java/tech.pegasys.signers.secp256k1/MultiKeyTomlFileUtil.java
@@ -37,7 +37,7 @@ public class MultiKeyTomlFileUtil {
             .withQuotedString("type", "azure-signer")
             .withQuotedString("key-vault-name", keyVaultName)
             .withQuotedString("key-name", "TestKey")
-            .withQuotedString("key-version", "7c01fe58d68148bba5824ce418241092")
+            .withQuotedString("key-version", "")
             .withQuotedString("client-id", clientId)
             .withQuotedString("client-secret", clientSecret)
             .withQuotedString("tenant-id", tenantId)

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -99,6 +99,7 @@ downloadLicenses {
                   license('New BSD License', 'http://www.opensource.org/licenses/bsd-license.php')
           ],
           (bsd3Clause): [
+                  'BSD-3-Clause',
                   'BSD 3-Clause',
                   'BSD 3-Clause "New" or "Revised" License (BSD-3-Clause)',
                   license('BSD 3-clause', 'http://opensource.org/licenses/BSD-3-Clause'),
@@ -162,7 +163,7 @@ downloadLicenses {
           (group('signers.signing')): apache,
           (group('signers.signing.secp256k1')): apache,
           (group('org.xipki.iaik')): iaik,
-
+          (group('io.netty')): apache,
   ]
 
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,15 +13,15 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
 
     dependency 'com.google.errorprone:error_prone_core:2.3.4'
 
     dependency 'com.google.guava:guava:28.2-jre'
 
-    dependency 'com.azure:azure-security-keyvault-secrets:4.2.1'
-    dependency 'com.azure:azure-security-keyvault-keys:4.1.5'
-    dependency 'com.azure:azure-identity:1.0.9'
+    dependency 'com.azure:azure-security-keyvault-secrets:4.3.3'
+    dependency 'com.azure:azure-security-keyvault-keys:4.3.3'
+    dependency 'com.azure:azure-identity:1.3.6'
 
     dependency 'commons-cli:commons-cli:1.4'
 

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -28,8 +28,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.web3j.crypto.Hash;
 import org.web3j.crypto.Sign;
 import org.web3j.crypto.Sign.SignatureData;
@@ -41,9 +39,7 @@ public class AzureKeyVaultSignerTest {
   private static final String keyVaultName = System.getenv("AZURE_KEY_VAULT_NAME");
   private static final String tenantId = System.getenv("AZURE_TENANT_ID");
   // uses curve name P-256K
-  private static final String KEY_NAME = "TestKey2";
-  // uses deprecated curve name SECP256K1
-  private static final String DEPRECATED_KEY_NAME = "TestKey";
+  private static final String KEY_NAME = "TestKey";
   private static final String UNSUPPORTED_CURVE_KEY_NAME = "TestKeyP521";
 
   @BeforeAll
@@ -66,11 +62,10 @@ public class AzureKeyVaultSignerTest {
     signer.sign(dataToHash);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {KEY_NAME, DEPRECATED_KEY_NAME})
-  void azureWithoutHashingDoesntHashData(final String keyName) throws SignatureException {
+  @Test
+  void azureWithoutHashingDoesntHashData() throws SignatureException {
     final AzureConfig config =
-        new AzureConfig(keyVaultName, keyName, "", clientId, clientSecret, tenantId);
+        new AzureConfig(keyVaultName, KEY_NAME, "", clientId, clientSecret, tenantId);
 
     final Signer azureNonHashedDataSigner =
         new AzureKeyVaultSignerFactory(false).createSigner(config);


### PR DESCRIPTION
**NOTE: Azure tests currently failing due to potential issue with config in key vault**

Remove support for previously deprecated SECP256K1 curve.
'TestKey' updated in vault to use P-256K instead of SECP256K1.
Blank key-version defaults to the latest key-version.