### PR TITLE
Update Vertx to 4.x and various dependencies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   executor_med:  # 2cpu, 4G ram
     docker:
-      - image: circleci/openjdk:11.0.8-jdk-buster
+      - image: cimg/openjdk:11.0
         auth:
           username: $DOCKER_USER_RO
           password: $DOCKER_PASSWORD_RO
@@ -18,7 +18,7 @@ executors:
 
   executor_large: # 4cpu, 8G ram
     docker:
-      - image: circleci/openjdk:11.0.8-jdk-buster
+      - image: cimg/openjdk:11.0
         auth:
           username: $DOCKER_USER_RO
           password: $DOCKER_PASSWORD_RO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 2.0.0
+### Features Added
+- Update various dependencies. 
+- Adding Vertx 4 which makes signers backward incompatible. 
+
+---
 ## 1.0.25
 ### Features Added
 - Update Tuweni libraries to 2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ org.gradle.jvmargs=-Xmx1g \
   --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
   --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-hashicorpVaultVersion=1.4.3
+hashicorpVaultVersion=1.9.2
 hashicorpVaultUrl=https://releases.hashicorp.com/vault

--- a/gradle/license-report-config/allowed-licenses.json
+++ b/gradle/license-report-config/allowed-licenses.json
@@ -63,6 +63,9 @@
     {
       "moduleLicense": "IAIK of Graz University of Technology License",
       "moduleName": "org.xipki.iaik:sunpkcs11-wrapper"
+    },
+    {
+      "moduleName": "io.netty:netty-tcnative-classes"
     }
   ],
   "overrideLicenses": [
@@ -112,6 +115,10 @@
     },
     {
       "moduleName": "org.ow2.asm:asm-util",
+      "moduleLicense": "Apache License, Version 2.0"
+    },
+    {
+      "moduleName": "io.netty:netty-tcnative-classes",
       "moduleLicense": "Apache License, Version 2.0"
     }
   ]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -33,7 +33,7 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.2.0'
 
-    dependencySet(group: 'io.vertx', version: '3.9.9') {
+    dependencySet(group: 'io.vertx', version: '4.2.3') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,23 +15,25 @@ dependencyManagement {
   dependencies {
     dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
 
-    dependencySet(group: 'com.google.errorprone', version: '2.7.1') {
+    dependencySet(group: 'com.google.errorprone', version: '2.10.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'
       entry 'error_prone_test_helpers'
     }
-    dependency 'com.google.guava:guava:28.2-jre'
+    dependency 'com.google.guava:guava:31.0.1-jre'
 
-    dependency 'com.azure:azure-security-keyvault-secrets:4.3.3'
-    dependency 'com.azure:azure-security-keyvault-keys:4.3.3'
-    dependency 'com.azure:azure-identity:1.3.6'
+    dependencySet(group: 'com.azure', version: '4.3.6') {
+      entry 'azure-security-keyvault-secrets'
+      entry 'azure-security-keyvault-keys'
+    }
+    dependency 'com.azure:azure-identity:1.4.3'
 
-    dependency 'commons-cli:commons-cli:1.4'
+    dependency 'commons-cli:commons-cli:1.5.0'
 
-    dependency 'commons-io:commons-io:2.8.0'
+    dependency 'commons-io:commons-io:2.11.0'
 
-    dependency 'io.rest-assured:rest-assured:4.2.0'
+    dependency 'io.rest-assured:rest-assured:4.4.0'
 
     dependencySet(group: 'io.vertx', version: '4.2.3') {
       entry 'vertx-codegen'
@@ -43,7 +45,7 @@ dependencyManagement {
 
     dependency 'javax.activation:activation:1.1.1'
 
-    dependency 'org.apache.commons:commons-lang3:3.11'
+    dependency 'org.apache.commons:commons-lang3:3.12.0'
 
     dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {
       entry 'log4j-api'
@@ -58,29 +60,33 @@ dependencyManagement {
       entry 'tuweni-toml'
     }
 
-    dependency 'org.assertj:assertj-core:3.15.0'
+    dependency 'org.assertj:assertj-core:3.22.0'
 
-    dependency 'org.awaitility:awaitility:4.0.2'
+    dependency 'org.awaitility:awaitility:4.1.1'
 
-    dependency 'org.bouncycastle:bcpkix-jdk15on:1.64'
-    dependency 'org.bouncycastle:bcprov-jdk15on:1.64'
+    dependencySet(group: 'org.bouncycastle', version: '1.70') {
+      entry 'bcpkix-jdk15on'
+      entry 'bcprov-jdk15on'
+    }
 
-    dependency 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    dependency 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-    dependency 'org.junit.jupiter:junit-jupiter-params:5.6.0'
+    dependencySet(group: 'org.junit.jupiter', version: '5.8.2') {
+      entry 'junit-jupiter-api'
+      entry 'junit-jupiter-engine'
+      entry 'junit-jupiter-params'
+    }
 
-    dependency 'org.mock-server:mockserver-netty:5.6.1'
+    dependency 'org.mock-server:mockserver-netty:5.11.2'
 
-    dependencySet(group: 'org.mockito', version: '4.0.0') {
+    dependencySet(group: 'org.mockito', version: '4.2.0') {
       entry 'mockito-core'
       entry 'mockito-inline'
       entry 'mockito-junit-jupiter'
     }
 
-    dependency 'org.web3j:core:4.5.14'
+    dependency 'org.web3j:core:4.8.9'
 
-    dependency 'org.zeroturnaround:zt-exec:1.11'
+    dependency 'org.zeroturnaround:zt-exec:1.12'
 
-    dependency 'org.xipki.iaik:sunpkcs11-wrapper:1.4.7'
+    dependency 'org.xipki.iaik:sunpkcs11-wrapper:1.4.8'
   }
 }

--- a/keystorage/hashicorp/src/integrationTest/java/tech/pegasys/signers/hashicorp/HashicorpIntegrationTest.java
+++ b/keystorage/hashicorp/src/integrationTest/java/tech/pegasys/signers/hashicorp/HashicorpIntegrationTest.java
@@ -23,7 +23,6 @@ import tech.pegasys.signers.hashicorp.config.loader.toml.TomlConfigLoader;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.KeyStore;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HttpsURLConnection;
 

--- a/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/FileDownloadOperation.java
+++ b/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/FileDownloadOperation.java
@@ -13,6 +13,7 @@
 package tech.pegasys.signers.interlock.vertx.operations;
 
 import static io.vertx.core.http.HttpHeaders.COOKIE;
+import static io.vertx.core.http.HttpMethod.GET;
 
 import tech.pegasys.signers.interlock.model.ApiAuth;
 
@@ -38,10 +39,15 @@ public class FileDownloadOperation extends AbstractOperation<String> {
   @Override
   protected void invoke() {
     httpClient
-        .get("/api/file/download?" + downloadIdQueryParam(downloadId), this::handle)
-        .exceptionHandler(this::handleException)
-        .putHeader(COOKIE.toString(), apiAuth.getCookies())
-        .end();
+        .request(GET, "/api/file/download?" + downloadIdQueryParam(downloadId))
+        .onSuccess(
+            request -> {
+              request.response().onSuccess(this::handle).onFailure(this::handleException);
+              request.exceptionHandler(this::handleException);
+              request.putHeader(COOKIE.toString(), apiAuth.getCookies());
+              request.end();
+            })
+        .onFailure(this::handleException);
   }
 
   @Override

--- a/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/LoginOperation.java
+++ b/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/LoginOperation.java
@@ -12,6 +12,9 @@
  */
 package tech.pegasys.signers.interlock.vertx.operations;
 
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+import static io.vertx.core.http.HttpMethod.POST;
+
 import tech.pegasys.signers.interlock.model.ApiAuth;
 
 import java.util.List;
@@ -41,10 +44,15 @@ public class LoginOperation extends AbstractOperation<ApiAuth> {
             .put("dispose", false)
             .encode();
     httpClient
-        .post("/api/auth/login", this::handle)
-        .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-        .exceptionHandler(this::handleException)
-        .end(body);
+        .request(POST, "/api/auth/login")
+        .onSuccess(
+            request -> {
+              request.response().onSuccess(this::handle).onFailure(this::handleException);
+              request.exceptionHandler(this::handleException);
+              request.putHeader(CONTENT_TYPE, "application/json");
+              request.end(body);
+            })
+        .onFailure(this::handleException);
   }
 
   @Override

--- a/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/LogoutOperation.java
+++ b/keystorage/interlock/src/main/java/tech/pegasys/signers/interlock/vertx/operations/LogoutOperation.java
@@ -13,6 +13,7 @@
 package tech.pegasys.signers.interlock.vertx.operations;
 
 import static io.vertx.core.http.HttpHeaders.COOKIE;
+import static io.vertx.core.http.HttpMethod.POST;
 import static tech.pegasys.signers.interlock.model.ApiAuth.XSRF_TOKEN_HEADER;
 
 import tech.pegasys.signers.interlock.model.ApiAuth;
@@ -31,10 +32,15 @@ public class LogoutOperation extends AbstractOperation<Void> {
   @Override
   protected void invoke() {
     httpClient
-        .post("/api/auth/logout", this::handle)
-        .exceptionHandler(this::handleException)
-        .putHeader(XSRF_TOKEN_HEADER, apiAuth.getToken())
-        .putHeader(COOKIE.toString(), apiAuth.getCookies())
-        .end();
+        .request(POST, "/api/auth/logout")
+        .onSuccess(
+            request -> {
+              request.response().onSuccess(this::handle).onFailure(this::handleException);
+              request.exceptionHandler(this::handleException);
+              request.putHeader(XSRF_TOKEN_HEADER, apiAuth.getToken());
+              request.putHeader(COOKIE.toString(), apiAuth.getCookies());
+              request.end();
+            })
+        .onFailure(this::handleException);
   }
 }


### PR DESCRIPTION
Update Vertx to 4.x and various other dependencies to latest versions. Make many signers modules backward incompatible. 