### PR TITLE
Fix connectingWithInvalidClientSecretThrowsException Azure AT

### DIFF
--- a/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
+++ b/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
@@ -55,7 +55,7 @@ public class AzureKeyVaultTest {
         createUsingClientSecretCredentials(CLIENT_ID, "invalid", TENANT_ID, VAULT_NAME);
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> azureKeyVault.fetchSecret(SECRET_NAME))
-        .withMessageContaining("Invalid client secret provided");
+        .withMessageContaining("Invalid client secret is provided");
   }
 
   @Test


### PR DESCRIPTION
Reverts change to expected Azure error message as Azure message has changed back.