### PR TITLE
Fixed aws test failures + refactoring

### DIFF
--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -13,7 +13,9 @@
 package tech.pegasys.signers.aws;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,15 +85,15 @@ public class AwsSecretsManager implements Closeable {
   private ListSecretsIterable listSecrets(
       final Collection<String> tagKeys, final Collection<String> tagValues) {
     final ListSecretsRequest.Builder listSecretsRequestBuilder = ListSecretsRequest.builder();
+    final List<Filter> filters = new ArrayList<>();
     if (!tagKeys.isEmpty()) {
-      listSecretsRequestBuilder.filters(
-          Filter.builder().key(FilterNameStringType.TAG_KEY).values(tagKeys).build());
+      filters.add(Filter.builder().key(FilterNameStringType.TAG_KEY).values(tagKeys).build());
     }
     if (!tagValues.isEmpty()) {
-      listSecretsRequestBuilder.filters(
-          Filter.builder().key(FilterNameStringType.TAG_VALUE).values(tagValues).build());
+      filters.add(Filter.builder().key(FilterNameStringType.TAG_VALUE).values(tagValues).build());
     }
-    return secretsManagerClient.listSecretsPaginator(listSecretsRequestBuilder.build());
+    return secretsManagerClient.listSecretsPaginator(
+        listSecretsRequestBuilder.filters(filters).build());
   }
 
   public <R> Collection<R> mapSecrets(

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -22,45 +22,47 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.Tag;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AwsSecretsManagerTest {
 
-  private final String RW_AWS_ACCESS_KEY_ID = System.getenv("RW_AWS_ACCESS_KEY_ID");
-  private final String RW_AWS_SECRET_ACCESS_KEY = System.getenv("RW_AWS_SECRET_ACCESS_KEY");
+  private static final String RW_AWS_ACCESS_KEY_ID = System.getenv("RW_AWS_ACCESS_KEY_ID");
+  private static final String RW_AWS_SECRET_ACCESS_KEY = System.getenv("RW_AWS_SECRET_ACCESS_KEY");
 
-  private final String RO_AWS_ACCESS_KEY_ID = System.getenv("RO_AWS_ACCESS_KEY_ID");
-  private final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("RO_AWS_SECRET_ACCESS_KEY");
-  private final String AWS_REGION = "us-east-2";
+  private static final String RO_AWS_ACCESS_KEY_ID = System.getenv("RO_AWS_ACCESS_KEY_ID");
+  private static final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("RO_AWS_SECRET_ACCESS_KEY");
+  private static final String AWS_REGION = "us-east-2";
 
-  private AwsSecretsManager awsSecretsManagerDefault;
-  private AwsSecretsManager awsSecretsManagerExplicit;
-  private AwsSecretsManager awsSecretsManagerInvalidCredentials;
-  private SecretsManagerClient secretsManagerClient;
-  private String secretName;
-  private String secretNamePrefix;
-  private List<String> secretNames;
-  private AbstractMap<String, String> secretTags;
+  private static AwsSecretsManager awsSecretsManagerDefault;
+  private static AwsSecretsManager awsSecretsManagerExplicit;
+  private static AwsSecretsManager awsSecretsManagerInvalidCredentials;
+  private static AwsBasicCredentials awsBasicCredentials;
+  private static StaticCredentialsProvider credentialsProvider;
+  private static SecretsManagerClient testSecretsManagerClient;
+  private static String testSecretName;
+  private static String testSecretNamePrefix;
+  private static List<String> testSecretNames;
+  private static AbstractMap<String, String> testSecretTags;
 
-  private static final String SECRET_VALUE =
+  private final String SECRET_VALUE =
       "{\"crypto\": {\"kdf\": {\"function\": \"scrypt\", \"params\": {\"dklen\": 32, \"n\": 262144, \"r\": 8, \"p\": 1, \"salt\": \"3d9b30b612f4f5e9423dc43c0490396798a179d35dd58d48dc1f5d6d42b07ab6\"}, \"message\": \"\"}, \"checksum\": {\"function\": \"sha256\", \"params\": {}, \"message\": \"c762b7453eab3332cda31d9dee1894cf541373617e591a8e7ab8f14f5830f723\"}, \"cipher\": {\"function\": \"aes-128-ctr\", \"params\": {\"iv\": \"095f79f6bb5daab60355ab6aa894b3c8\"}, \"message\": \"4ca342a769ec1c00d6a6d69e18cdf821f42849d4431da7df827b01ba162ed763\"}}, \"description\": \"\", \"pubkey\": \"8fb7c68f3291b8db46ef86a8b9544cad7052dd7cf817862063d1f151f3c443cd3907830b09a86fe0513f0e863beccf25\", \"path\": \"m/12381/3600/0/0/0\", \"uuid\": \"88fc9701-8670-4378-a3ba-00be25c1330c\", \"version\": 4}";
 
-  private void verifyEnvironmentVariables() {
+  @BeforeAll
+  static void verifyEnvironmentVariables() {
     Assumptions.assumeTrue(
         RW_AWS_ACCESS_KEY_ID != null, "Set RW_AWS_ACCESS_KEY_ID environment variable");
     Assumptions.assumeTrue(
@@ -71,7 +73,189 @@ class AwsSecretsManagerTest {
         RO_AWS_SECRET_ACCESS_KEY != null, "Set RO_AWS_SECRET_ACCESS_KEY environment variable");
   }
 
-  private void setupSecretsManagers() {
+  @BeforeAll
+  static void setup() {
+    initAwsSecretsManagers();
+    initTestSecretsManager();
+    initTestVariables();
+  }
+
+  @AfterAll
+  static void teardown() {
+    if (awsSecretsManagerDefault != null
+        || awsSecretsManagerExplicit != null
+        || testSecretsManagerClient != null) {
+      deleteSecrets();
+      closeClients();
+    }
+  }
+
+  @BeforeEach
+  void initTestClients() {
+    initAwsSecretsManagers();
+  }
+
+  @AfterEach
+  void closeTestClients() {
+    closeAwsSecretsManagers();
+  }
+
+  @Test
+  void fetchSecretWithDefaultManager() {
+    createSecret(false, false);
+
+    Optional<String> secret = awsSecretsManagerDefault.fetchSecret(testSecretName);
+    assertThat(secret).hasValue(SECRET_VALUE);
+
+    deleteSecrets();
+  }
+
+  @Test
+  void fetchSecretWithExplicitManager() {
+    createSecret(false, false);
+
+    Optional<String> secret = awsSecretsManagerExplicit.fetchSecret(testSecretName);
+    assertThat(secret).hasValue(SECRET_VALUE);
+
+    deleteSecrets();
+  }
+
+  @Test
+  void fetchSecretWithInvalidCredentialsReturnsEmpty() {
+    createSecret(false, false);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> awsSecretsManagerInvalidCredentials.fetchSecret(testSecretName))
+        .withMessageContaining("Failed to fetch secret from AWS Secrets Manager.");
+
+    deleteSecrets();
+  }
+
+  @Test
+  void fetchingNonExistentSecretReturnsEmpty() {
+    createSecret(false, false);
+
+    Optional<String> secret = awsSecretsManagerDefault.fetchSecret("signers-aws-integration/empty");
+    assertThat(secret).isEmpty();
+
+    deleteSecrets();
+  }
+
+  @Test
+  void listAndMapSingleSecretWithSingleTag() {
+    createSecret(false, false);
+
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(), testSecretTags.values(), AbstractMap.SimpleEntry::new);
+
+    testSecretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+
+    deleteSecrets();
+  }
+
+  @Test
+  void listAndMapSingleSecretWithMultipleTags() {
+    createSecret(true, false);
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(), testSecretTags.values(), AbstractMap.SimpleEntry::new);
+
+    testSecretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+
+    deleteSecrets();
+  }
+
+  @Test
+  void listAndMapMultipleSecretsWithMultipleTags() {
+    createSecret(true, false);
+    createSecret(true, false);
+
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(), testSecretTags.values(), AbstractMap.SimpleEntry::new);
+    testSecretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+
+    deleteSecrets();
+  }
+
+  @Test
+  void listAndMapMultipleSecretsWithSharedTags() {
+    createSecret(false, false);
+    createSecret(false, true);
+
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(), testSecretTags.values(), AbstractMap.SimpleEntry::new);
+    testSecretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+
+    deleteSecrets();
+  }
+
+  @Test
+  void listAndMapMultipleSecretsWithMultipleAndSharedTags() {
+    createSecret(true, false);
+    createSecret(false, true);
+
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(), testSecretTags.values(), AbstractMap.SimpleEntry::new);
+    testSecretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+
+    deleteSecrets();
+  }
+
+  @Test
+  void throwsAwayObjectsThatFailMapper() {
+    createSecret(false, false);
+    createSecret(false, false);
+
+    final String failEntryName = testSecretNames.get(1);
+    Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(),
+            testSecretTags.values(),
+            (name, value) -> {
+              if (name.equals(failEntryName)) {
+                throw new RuntimeException("Arbitrary Failure");
+              }
+              return new AbstractMap.SimpleEntry<>(name, value);
+            });
+
+    validateMappedSecret(secretEntries, testSecretNames.get(0));
+    final Optional<AbstractMap.SimpleEntry<String, String>> failEntry =
+        secretEntries.stream().filter(e -> e.getKey().equals(failEntryName)).findAny();
+    assertThat(failEntry).isEmpty();
+
+    deleteSecrets();
+  }
+
+  @Test
+  void throwsAwayObjectsWhichMapToNull() {
+    createSecret(false, false);
+    createSecret(false, false);
+
+    final String nullEntryName = testSecretNames.get(1);
+    Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            testSecretTags.keySet(),
+            testSecretTags.values(),
+            (name, value) -> {
+              if (name.equals(nullEntryName)) {
+                return null;
+              }
+              return new AbstractMap.SimpleEntry<>(name, value);
+            });
+
+    validateMappedSecret(secretEntries, testSecretNames.get(0));
+    final Optional<AbstractMap.SimpleEntry<String, String>> nullEntry =
+        secretEntries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
+    assertThat(nullEntry).isEmpty();
+
+    deleteSecrets();
+  }
+
+  private static void initAwsSecretsManagers() {
     awsSecretsManagerDefault = AwsSecretsManager.createAwsSecretsManager();
     awsSecretsManagerExplicit =
         AwsSecretsManager.createAwsSecretsManager(
@@ -80,77 +264,89 @@ class AwsSecretsManagerTest {
         AwsSecretsManager.createAwsSecretsManager("invalid", "invalid", AWS_REGION);
   }
 
-  private void setupSecretsManagerClient() {
-    final AwsBasicCredentials awsBasicCredentials =
+  private static void initTestSecretsManager() {
+    awsBasicCredentials =
         AwsBasicCredentials.create(RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
-    final StaticCredentialsProvider credentialsProvider =
-        StaticCredentialsProvider.create(awsBasicCredentials);
-    secretsManagerClient =
+    credentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
+    testSecretsManagerClient =
         SecretsManagerClient.builder()
             .credentialsProvider(credentialsProvider)
             .region(Region.of(AWS_REGION))
             .build();
   }
 
-  private void initializeVariables() {
-    secretNames = new ArrayList<>();
-    secretTags = new HashMap<String, String>();
+  private static void initTestVariables() {
+    testSecretNames = new ArrayList<>();
+    testSecretTags = new HashMap<>();
   }
 
-  private void closeClients() {
+  private static void closeTestSecretsManager() {
+    testSecretsManagerClient.close();
+  }
+
+  private static void closeAwsSecretsManagers() {
     awsSecretsManagerDefault.close();
     awsSecretsManagerExplicit.close();
     awsSecretsManagerInvalidCredentials.close();
-    secretsManagerClient.close();
   }
 
-  void createSecret(
-      final boolean multipleSecrets, final boolean multipleTags, final boolean sharedTag) {
-    secretNamePrefix = "signers-aws-integration/";
-    secretName = secretNamePrefix + UUID.randomUUID();
-    secretNames.add(secretName);
+  private static void closeClients() {
+    closeAwsSecretsManagers();
+    closeTestSecretsManager();
+  }
+
+  private CreateSecretResponse createSecret(final boolean multipleTags, final boolean sharedTag) {
+    testSecretNamePrefix = "signers-aws-integration/";
+    testSecretName = testSecretNamePrefix + UUID.randomUUID();
+    testSecretNames.add(testSecretName);
 
     final List<Tag> tags = new ArrayList<>();
 
     if (sharedTag) {
-      secretTags
+      testSecretTags
           .entrySet()
           .forEach(
               entry -> tags.add(Tag.builder().key(entry.getKey()).value(entry.getValue()).build()));
-    } else if (multipleTags) {
-      tags.add(Tag.builder().key(secretNamePrefix + UUID.randomUUID()).value(secretName).build());
+    } else {
+      tags.add(
+          Tag.builder()
+              .key(testSecretNamePrefix + UUID.randomUUID())
+              .value(testSecretName)
+              .build());
     }
 
-    tags.add(Tag.builder().key(secretNamePrefix + UUID.randomUUID()).value(secretName).build());
+    if (multipleTags) {
+      tags.add(
+          Tag.builder()
+              .key(testSecretNamePrefix + UUID.randomUUID())
+              .value(testSecretName)
+              .build());
+    }
 
     tags.forEach(
         tag -> {
-          secretTags.put(tag.key(), tag.value());
+          testSecretTags.put(tag.key(), tag.value());
         });
 
     final CreateSecretRequest secretRequest =
         CreateSecretRequest.builder()
-            .name(secretName)
+            .name(testSecretName)
             .secretString(SECRET_VALUE)
             .tags(tags)
             .build();
-    secretsManagerClient.createSecret(secretRequest);
 
-    if (multipleSecrets) {
-      createSecret(false, multipleTags, sharedTag);
-    }
+    return testSecretsManagerClient.createSecret(secretRequest);
   }
 
-  @AfterEach
-  void deleteSecrets() {
-    secretNames.forEach(
+  private static void deleteSecrets() {
+    testSecretNames.forEach(
         name -> {
-          final DeleteSecretRequest secretRequest =
+          final DeleteSecretRequest deleteSecretRequest =
               DeleteSecretRequest.builder().secretId(name).build();
-          secretsManagerClient.deleteSecret(secretRequest);
+          testSecretsManagerClient.deleteSecret(deleteSecretRequest);
         });
-    secretNames.clear();
-    secretTags.clear();
+    testSecretNames.clear();
+    testSecretTags.clear();
   }
 
   private void validateMappedSecret(
@@ -159,167 +355,5 @@ class AwsSecretsManagerTest {
     final Optional<AbstractMap.SimpleEntry<String, String>> secretEntry =
         secretEntries.stream().filter(e -> e.getKey().equals(secretName)).findAny();
     assertThat(secretEntry).isPresent();
-    assertThat(secretEntry.get().getValue()).isEqualTo(SECRET_VALUE);
-  }
-
-  @BeforeAll
-  void setup() {
-    verifyEnvironmentVariables();
-    setupSecretsManagers();
-    setupSecretsManagerClient();
-    initializeVariables();
-  }
-
-  @AfterAll
-  void teardown() {
-    if (awsSecretsManagerDefault != null
-        || awsSecretsManagerExplicit != null
-        || secretsManagerClient != null) {
-      deleteSecrets();
-      closeClients();
-    }
-  }
-
-  @Test
-  void fetchSecretWithDefaultManager() {
-    createSecret(false, false, false);
-    Optional<String> secret = awsSecretsManagerDefault.fetchSecret(secretName);
-    assertThat(secret).hasValue(SECRET_VALUE);
-  }
-
-  @Test
-  void fetchSecretWithExplicitManager() {
-    createSecret(false, false, false);
-    Optional<String> secret = awsSecretsManagerExplicit.fetchSecret(secretName);
-    assertThat(secret).hasValue(SECRET_VALUE);
-  }
-
-  @Test
-  void fetchSecretWithInvalidCredentialsReturnsEmpty() {
-    createSecret(false, false, false);
-    assertThatExceptionOfType(RuntimeException.class)
-        .isThrownBy(() -> awsSecretsManagerInvalidCredentials.fetchSecret(secretName))
-        .withMessageContaining("Failed to fetch secret from AWS Secrets Manager.");
-  }
-
-  @Test
-  void fetchingNonExistentSecretReturnsEmpty() {
-    createSecret(false, false, false);
-    Optional<String> secret = awsSecretsManagerDefault.fetchSecret("signers-aws-integration/empty");
-    assertThat(secret).isEmpty();
-  }
-
-  @Test
-  void listAndMapSingleSecretWithSingleTag() {
-    createSecret(false, false, false);
-
-    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
-
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
-  }
-
-  @Test
-  void listAndMapSingleSecretWithMultipleTags() {
-    createSecret(false, true, false);
-
-    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
-
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
-  }
-
-  @Test
-  void listAndMapMultipleSecretsWithMultipleTags() {
-    createSecret(true, true, false);
-
-    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
-
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
-  }
-
-  @Test
-  void listAndMapMultipleSecretsWithSharedTags() {
-    createSecret(true, false, true);
-
-    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
-
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
-  }
-
-  @Test
-  void listAndMapMultipleSecretsWithMultipleAndSharedTags() {
-    createSecret(true, false, true);
-    createSecret(true, true, false);
-
-    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
-
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
-  }
-
-  @Test
-  void throwsAwayObjectsThatFailMapper() {
-    createSecret(true, false, false);
-
-    final String failEntryName = secretNames.get(1);
-
-    Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            (name, value) -> {
-              if (name.equals(failEntryName)) {
-                throw new RuntimeException("Arbitrary Failure");
-              }
-              return new AbstractMap.SimpleEntry<>(name, value);
-            });
-
-    validateMappedSecret(secretEntries, secretNames.get(0));
-
-    final Optional<AbstractMap.SimpleEntry<String, String>> failEntry =
-        secretEntries.stream().filter(e -> e.getKey().equals(failEntryName)).findAny();
-    assertThat(failEntry).isEmpty();
-  }
-
-  @Test
-  void throwsAwayObjectsWhichMapToNull() {
-    createSecret(true, false, false);
-
-    final String nullEntryName = secretNames.get(1);
-
-    Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
-        awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            (name, value) -> {
-              if (name.equals(nullEntryName)) {
-                return null;
-              }
-              return new AbstractMap.SimpleEntry<>(name, value);
-            });
-
-    validateMappedSecret(secretEntries, secretNames.get(0));
-
-    final Optional<AbstractMap.SimpleEntry<String, String>> nullEntry =
-        secretEntries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
-    assertThat(nullEntry).isEmpty();
   }
 }

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,9 +91,15 @@ class AwsSecretsManagerTest {
   }
 
   @BeforeEach
-  void initTestClients() {
-    deleteSecrets();
+  void startup() {
+    initTestSecretsManager();
     initTestVariables();
+  }
+
+  @AfterEach
+  void cleanup() {
+    deleteSecrets();
+    closeTestSecretsManager();
   }
 
   @Test

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -51,7 +51,7 @@ class AwsSecretsManagerTest {
   private static AwsSecretsManager awsSecretsManagerInvalidCredentials;
   private static AwsBasicCredentials awsBasicCredentials;
   private static StaticCredentialsProvider credentialsProvider;
-  private static SecretsManagerClient testSecretsManagerClient;
+  private static SecretsManagerAsyncClient testSecretsManagerClient;
   private static String testSecretName;
   private static String testSecretNamePrefix;
   private static List<String> testSecretNames;
@@ -240,7 +240,7 @@ class AwsSecretsManagerTest {
         AwsBasicCredentials.create(RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
     credentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
     testSecretsManagerClient =
-        SecretsManagerClient.builder()
+          SecretsManagerAsyncClient.builder()
             .credentialsProvider(credentialsProvider)
             .region(Region.of(AWS_REGION))
             .build();
@@ -272,7 +272,7 @@ class AwsSecretsManagerTest {
 
   private static void waitUntilSecretAvailable(final String secretName) {
     testSecretsManagerClient.getSecretValue(
-        GetSecretValueRequest.builder().secretId(secretName).build());
+        GetSecretValueRequest.builder().secretId(secretName).build()).join();
   }
 
   private static void createSecret(final boolean multipleTags, final boolean sharedTags) {
@@ -305,9 +305,9 @@ class AwsSecretsManagerTest {
           testSecretTags.put(tag.key(), tag.value());
         });
 
-    testSecretsManagerClient.createSecret(secretRequest);
-    waitUntilSecretAvailable(testSecretName);
+    testSecretsManagerClient.createSecret(secretRequest).join();
     testSecretNames.add(testSecretName);
+    waitUntilSecretAvailable(testSecretName);
   }
 
   private static void deleteSecrets() {
@@ -315,7 +315,7 @@ class AwsSecretsManagerTest {
         name -> {
           final DeleteSecretRequest deleteSecretRequest =
               DeleteSecretRequest.builder().secretId(name).build();
-          testSecretsManagerClient.deleteSecret(deleteSecretRequest);
+          testSecretsManagerClient.deleteSecret(deleteSecretRequest).join();
         });
     testSecretNames.clear();
     testSecretTags.clear();

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -51,7 +51,10 @@ class AwsSecretsManagerTest {
   private static final String AWS_REGION = "us-east-2";
 
   private static final String SECRET_NAME_PREFIX = "signers-aws-integration/";
-  private static final String SECRET_VALUE = "secret-value";
+  private static final String SECRET_VALUE1 = "secret-value1";
+  private static final String SECRET_VALUE2 = "secret-value2";
+  private static final String SECRET_VALUE3 = "secret-value3";
+  private static final String SECRET_VALUE4 = "secret-value4";
 
   private AwsSecretsManager awsSecretsManagerDefault;
   private AwsSecretsManager awsSecretsManagerExplicit;
@@ -96,13 +99,13 @@ class AwsSecretsManagerTest {
   @Test
   void fetchSecretWithDefaultManager() {
     Optional<String> secret = awsSecretsManagerDefault.fetchSecret(secretName1WithTagKey1ValA);
-    assertThat(secret).hasValue(SECRET_VALUE);
+    assertThat(secret).hasValue(SECRET_VALUE1);
   }
 
   @Test
   void fetchSecretWithExplicitManager() {
     Optional<String> secret = awsSecretsManagerExplicit.fetchSecret(secretName1WithTagKey1ValA);
-    assertThat(secret).hasValue(SECRET_VALUE);
+    assertThat(secret).hasValue(SECRET_VALUE1);
   }
 
   @Test
@@ -153,7 +156,9 @@ class AwsSecretsManagerTest {
     assertThat(secretEntries.stream().map(e -> e.getKey()))
         .contains(secretName1WithTagKey1ValA, secretName2WithTagKey1ValB)
         .doesNotContain(secretName3WithTagKey2ValC, secretName4WithTagKey2ValB);
-    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
+    assertThat(secretEntries.stream().map(e -> e.getValue()))
+        .contains(SECRET_VALUE1, SECRET_VALUE2)
+        .doesNotContain(SECRET_VALUE3, SECRET_VALUE4);
   }
 
   @Test
@@ -166,7 +171,9 @@ class AwsSecretsManagerTest {
         .contains(
             secretName2WithTagKey1ValB, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB)
         .doesNotContain(secretName1WithTagKey1ValA);
-    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
+    assertThat(secretEntries.stream().map(e -> e.getValue()))
+        .contains(SECRET_VALUE2, SECRET_VALUE3, SECRET_VALUE4)
+        .doesNotContain(SECRET_VALUE1);
   }
 
   @Test
@@ -179,7 +186,9 @@ class AwsSecretsManagerTest {
         .contains(secretName2WithTagKey1ValB)
         .doesNotContain(
             secretName1WithTagKey1ValA, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB);
-    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
+    assertThat(secretEntries.stream().map(e -> e.getValue()))
+        .contains(SECRET_VALUE2)
+        .doesNotContain(SECRET_VALUE1, SECRET_VALUE3, SECRET_VALUE4);
   }
 
   @Test
@@ -235,14 +244,14 @@ class AwsSecretsManagerTest {
     closeTestSecretsManager();
   }
 
-  private String createSecret(final Tag tag)
+  private String createSecret(final Tag tag, String secretValue)
       throws ExecutionException, InterruptedException, TimeoutException {
     final String testSecretName = SECRET_NAME_PREFIX + UUID.randomUUID();
 
     final CreateSecretRequest secretRequest =
         CreateSecretRequest.builder()
             .name(testSecretName)
-            .secretString(SECRET_VALUE)
+            .secretString(secretValue)
             .tags(tag)
             .build();
 
@@ -251,20 +260,21 @@ class AwsSecretsManagerTest {
     return testSecretName;
   }
 
-  private String createTestSecret(final String tagKey, final String tagVal) throws Exception {
+  private String createTestSecret(
+      final String tagKey, final String tagVal, final String secretValue) throws Exception {
     final Tag testSecretTag = Tag.builder().key(tagKey).value(tagVal).build();
     try {
-      return createSecret(testSecretTag);
+      return createSecret(testSecretTag, secretValue);
     } catch (Exception e) {
       throw new Exception(e.getMessage());
     }
   }
 
   private void createTestSecrets() throws Exception {
-    secretName1WithTagKey1ValA = createTestSecret("tagKey1", "tagValA");
-    secretName2WithTagKey1ValB = createTestSecret("tagKey1", "tagValB");
-    secretName3WithTagKey2ValC = createTestSecret("tagKey2", "tagValC");
-    secretName4WithTagKey2ValB = createTestSecret("tagKey2", "tagValB");
+    secretName1WithTagKey1ValA = createTestSecret("tagKey1", "tagValA", SECRET_VALUE1);
+    secretName2WithTagKey1ValB = createTestSecret("tagKey1", "tagValB", SECRET_VALUE2);
+    secretName3WithTagKey2ValC = createTestSecret("tagKey2", "tagValC", SECRET_VALUE3);
+    secretName4WithTagKey2ValB = createTestSecret("tagKey2", "tagValB", SECRET_VALUE4);
     testSecretNames = new ArrayList<>();
     testSecretNames.addAll(
         List.of(

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -205,6 +205,27 @@ class AwsSecretsManagerTest {
             });
 
     assertThat(secretEntries.stream().map(e -> e.getKey()))
+        .contains(
+            secretName2WithTagKey1ValB, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB)
+        .doesNotContain(secretName1WithTagKey1ValA);
+  }
+
+  @Test
+  void throwsAwayObjectsThatFailMapper() {
+    final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
+        awsSecretsManagerExplicit.mapSecrets(
+            Collections.emptyList(),
+            Collections.emptyList(),
+            (name, value) -> {
+              if (name.equals(secretName1WithTagKey1ValA)) {
+                throw new RuntimeException("Arbitrary Failure");
+              }
+              return new AbstractMap.SimpleEntry<>(name, value);
+            });
+
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
+        .contains(
+            secretName2WithTagKey1ValB, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB)
         .doesNotContain(secretName1WithTagKey1ValA);
   }
 

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -361,13 +361,8 @@ class AwsSecretsManagerTest {
       final Map<String, String> testTags) {
     testTags.keySet().stream()
         .filter(tagKey -> testSecretNames.contains(tagKey))
-        .collect(Collectors.toList())
-        .forEach(
-            tagKey ->
-                assertThat(tagKey)
-                    .isIn(
-                        secretEntries.stream()
-                            .map(entry -> entry.getKey())
-                            .collect(Collectors.toList())));
+        .forEach(tagKey ->
+            assertThat(tagKey).isIn(secretEntries.stream().map(e -> e.getKey()))
+        );
   }
 }

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -20,49 +20,52 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.Tag;
 
-@Disabled("Disabled temporarily as this is failing in CI")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AwsSecretsManagerTest {
 
-  private final String RW_AWS_ACCESS_KEY_ID = System.getenv("RW_AWS_ACCESS_KEY_ID");
-  private final String RW_AWS_SECRET_ACCESS_KEY = System.getenv("RW_AWS_SECRET_ACCESS_KEY");
+  private static final String RW_AWS_ACCESS_KEY_ID = System.getenv("RW_AWS_ACCESS_KEY_ID");
+  private static final String RW_AWS_SECRET_ACCESS_KEY = System.getenv("RW_AWS_SECRET_ACCESS_KEY");
 
-  private final String RO_AWS_ACCESS_KEY_ID = System.getenv("RO_AWS_ACCESS_KEY_ID");
-  private final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("RO_AWS_SECRET_ACCESS_KEY");
-  private final String AWS_REGION = "us-east-2";
+  private static final String RO_AWS_ACCESS_KEY_ID = System.getenv("RO_AWS_ACCESS_KEY_ID");
+  private static final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("RO_AWS_SECRET_ACCESS_KEY");
+  private static final String AWS_REGION = "us-east-2";
 
-  private AwsSecretsManager awsSecretsManagerDefault;
-  private AwsSecretsManager awsSecretsManagerExplicit;
-  private AwsSecretsManager awsSecretsManagerInvalidCredentials;
-  private SecretsManagerClient secretsManagerClient;
-  private String secretName;
-  private String secretNamePrefix;
-  private List<String> secretNames;
-  private AbstractMap<String, String> secretTags;
+  private static AwsSecretsManager awsSecretsManagerDefault;
+  private static AwsSecretsManager awsSecretsManagerExplicit;
+  private static AwsSecretsManager awsSecretsManagerInvalidCredentials;
+  private static AwsBasicCredentials awsBasicCredentials;
+  private static StaticCredentialsProvider credentialsProvider;
+  private static SecretsManagerAsyncClient testSecretsManagerClient;
+  private static String testSecretName;
+  private static String testSecretNamePrefix;
+  private static List<String> testSecretNames;
+  private static Map<String, String> allTestSecretTags;
+  private static Map<String, String> testSecretSingleTag;
+  private static Map<String, String> testSecretMultipleTags;
+  private static Map<String, String> testSecretSingleSharedTag;
+  private static Map<String, String> testSecretMultipleSharedTags;
 
   private static final String SECRET_VALUE =
       "{\"crypto\": {\"kdf\": {\"function\": \"scrypt\", \"params\": {\"dklen\": 32, \"n\": 262144, \"r\": 8, \"p\": 1, \"salt\": \"3d9b30b612f4f5e9423dc43c0490396798a179d35dd58d48dc1f5d6d42b07ab6\"}, \"message\": \"\"}, \"checksum\": {\"function\": \"sha256\", \"params\": {}, \"message\": \"c762b7453eab3332cda31d9dee1894cf541373617e591a8e7ab8f14f5830f723\"}, \"cipher\": {\"function\": \"aes-128-ctr\", \"params\": {\"iv\": \"095f79f6bb5daab60355ab6aa894b3c8\"}, \"message\": \"4ca342a769ec1c00d6a6d69e18cdf821f42849d4431da7df827b01ba162ed763\"}}, \"description\": \"\", \"pubkey\": \"8fb7c68f3291b8db46ef86a8b9544cad7052dd7cf817862063d1f151f3c443cd3907830b09a86fe0513f0e863beccf25\", \"path\": \"m/12381/3600/0/0/0\", \"uuid\": \"88fc9701-8670-4378-a3ba-00be25c1330c\", \"version\": 4}";
 
-  private void verifyEnvironmentVariables() {
+  static void verifyEnvironmentVariables() {
     Assumptions.assumeTrue(
         RW_AWS_ACCESS_KEY_ID != null, "Set RW_AWS_ACCESS_KEY_ID environment variable");
     Assumptions.assumeTrue(
@@ -73,220 +76,117 @@ class AwsSecretsManagerTest {
         RO_AWS_SECRET_ACCESS_KEY != null, "Set RO_AWS_SECRET_ACCESS_KEY environment variable");
   }
 
-  private void setupSecretsManagers() {
-    awsSecretsManagerDefault = AwsSecretsManager.createAwsSecretsManager();
-    awsSecretsManagerExplicit =
-        AwsSecretsManager.createAwsSecretsManager(
-            RO_AWS_ACCESS_KEY_ID, RO_AWS_SECRET_ACCESS_KEY, AWS_REGION);
-    awsSecretsManagerInvalidCredentials =
-        AwsSecretsManager.createAwsSecretsManager("invalid", "invalid", AWS_REGION);
-  }
-
-  private void setupSecretsManagerClient() {
-    final AwsBasicCredentials awsBasicCredentials =
-        AwsBasicCredentials.create(RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
-    final StaticCredentialsProvider credentialsProvider =
-        StaticCredentialsProvider.create(awsBasicCredentials);
-    secretsManagerClient =
-        SecretsManagerClient.builder()
-            .credentialsProvider(credentialsProvider)
-            .region(Region.of(AWS_REGION))
-            .build();
-  }
-
-  private void initializeVariables() {
-    secretNames = new ArrayList<>();
-    secretTags = new HashMap<String, String>();
-  }
-
-  private void closeClients() {
-    awsSecretsManagerDefault.close();
-    awsSecretsManagerExplicit.close();
-    awsSecretsManagerInvalidCredentials.close();
-    secretsManagerClient.close();
-  }
-
-  void createSecret(
-      final boolean multipleSecrets, final boolean multipleTags, final boolean sharedTag) {
-    secretNamePrefix = "signers-aws-integration/";
-    secretName = secretNamePrefix + UUID.randomUUID();
-    secretNames.add(secretName);
-
-    final List<Tag> tags = new ArrayList<>();
-
-    if (sharedTag) {
-      secretTags
-          .entrySet()
-          .forEach(
-              entry -> tags.add(Tag.builder().key(entry.getKey()).value(entry.getValue()).build()));
-    } else if (multipleTags) {
-      tags.add(Tag.builder().key(secretNamePrefix + UUID.randomUUID()).value(secretName).build());
-    }
-
-    tags.add(Tag.builder().key(secretNamePrefix + UUID.randomUUID()).value(secretName).build());
-
-    tags.forEach(
-        tag -> {
-          secretTags.put(tag.key(), tag.value());
-        });
-
-    final CreateSecretRequest secretRequest =
-        CreateSecretRequest.builder()
-            .name(secretName)
-            .secretString(SECRET_VALUE)
-            .tags(tags)
-            .build();
-    secretsManagerClient.createSecret(secretRequest);
-
-    if (multipleSecrets) {
-      createSecret(false, multipleTags, sharedTag);
-    }
-  }
-
-  @AfterEach
-  void deleteSecrets() {
-    secretNames.forEach(
-        name -> {
-          final DeleteSecretRequest secretRequest =
-              DeleteSecretRequest.builder().secretId(name).build();
-          secretsManagerClient.deleteSecret(secretRequest);
-        });
-    secretNames.clear();
-    secretTags.clear();
-  }
-
-  private void validateMappedSecret(
-      final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries,
-      final String secretName) {
-    final Optional<AbstractMap.SimpleEntry<String, String>> secretEntry =
-        secretEntries.stream().filter(e -> e.getKey().equals(secretName)).findAny();
-    assertThat(secretEntry).isPresent();
-    assertThat(secretEntry.get().getValue()).isEqualTo(SECRET_VALUE);
-  }
-
   @BeforeAll
-  void setup() {
+  static void setup() {
     verifyEnvironmentVariables();
-    setupSecretsManagers();
-    setupSecretsManagerClient();
-    initializeVariables();
+    initAwsSecretsManagers();
+    initTestSecretsManagerClient();
+    initTestVariables();
+    createTestSecrets();
   }
 
   @AfterAll
-  void teardown() {
+  static void teardown() {
     if (awsSecretsManagerDefault != null
         || awsSecretsManagerExplicit != null
-        || secretsManagerClient != null) {
-      deleteSecrets();
+        || testSecretsManagerClient != null) {
+      deleteTestSecrets();
       closeClients();
     }
   }
 
   @Test
   void fetchSecretWithDefaultManager() {
-    createSecret(false, false, false);
-    Optional<String> secret = awsSecretsManagerDefault.fetchSecret(secretName);
+    Optional<String> secret = awsSecretsManagerDefault.fetchSecret(testSecretName);
     assertThat(secret).hasValue(SECRET_VALUE);
   }
 
   @Test
   void fetchSecretWithExplicitManager() {
-    createSecret(false, false, false);
-    Optional<String> secret = awsSecretsManagerExplicit.fetchSecret(secretName);
+    Optional<String> secret = awsSecretsManagerExplicit.fetchSecret(testSecretName);
     assertThat(secret).hasValue(SECRET_VALUE);
   }
 
   @Test
   void fetchSecretWithInvalidCredentialsReturnsEmpty() {
-    createSecret(false, false, false);
     assertThatExceptionOfType(RuntimeException.class)
-        .isThrownBy(() -> awsSecretsManagerInvalidCredentials.fetchSecret(secretName))
+        .isThrownBy(() -> awsSecretsManagerInvalidCredentials.fetchSecret(testSecretName))
         .withMessageContaining("Failed to fetch secret from AWS Secrets Manager.");
   }
 
   @Test
   void fetchingNonExistentSecretReturnsEmpty() {
-    createSecret(false, false, false);
     Optional<String> secret = awsSecretsManagerDefault.fetchSecret("signers-aws-integration/empty");
     assertThat(secret).isEmpty();
   }
 
   @Test
   void listAndMapSingleSecretWithSingleTag() {
-    createSecret(false, false, false);
-
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
+            testSecretSingleTag.keySet(),
+            testSecretSingleTag.values(),
             AbstractMap.SimpleEntry::new);
 
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+    validateMappedSecret(secretEntries, testSecretSingleTag);
   }
 
   @Test
   void listAndMapSingleSecretWithMultipleTags() {
-    createSecret(false, true, false);
-
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
+            testSecretMultipleTags.keySet(),
+            testSecretMultipleTags.values(),
             AbstractMap.SimpleEntry::new);
 
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+    validateMappedSecret(secretEntries, testSecretMultipleTags);
   }
 
   @Test
   void listAndMapMultipleSecretsWithMultipleTags() {
-    createSecret(true, true, false);
+    final HashMap<String, String> testTags = new HashMap<>();
+    testTags.putAll(testSecretMultipleTags);
+    testTags.putAll(testSecretSingleTag);
 
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
+            testTags.keySet(), testTags.values(), AbstractMap.SimpleEntry::new);
 
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+    validateMappedSecret(secretEntries, testTags);
   }
 
   @Test
   void listAndMapMultipleSecretsWithSharedTags() {
-    createSecret(true, false, true);
+    final HashMap<String, String> testTags = new HashMap<>();
+    testTags.putAll(testSecretSingleTag);
+    testTags.putAll(testSecretSingleSharedTag);
 
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
-            AbstractMap.SimpleEntry::new);
+            testTags.keySet(), testTags.values(), AbstractMap.SimpleEntry::new);
 
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+    validateMappedSecret(secretEntries, testTags);
   }
 
   @Test
   void listAndMapMultipleSecretsWithMultipleAndSharedTags() {
-    createSecret(true, false, true);
-    createSecret(true, true, false);
-
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
+            testSecretMultipleSharedTags.keySet(),
+            testSecretMultipleSharedTags.values(),
             AbstractMap.SimpleEntry::new);
 
-    secretNames.forEach(secretName -> validateMappedSecret(secretEntries, secretName));
+    validateMappedSecret(secretEntries, testSecretMultipleSharedTags);
   }
 
   @Test
   void throwsAwayObjectsThatFailMapper() {
-    createSecret(true, false, false);
-
-    final String failEntryName = secretNames.get(1);
+    final String failEntryName = testSecretNames.get(1);
 
     Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
+            allTestSecretTags.keySet(),
+            allTestSecretTags.values(),
             (name, value) -> {
               if (name.equals(failEntryName)) {
                 throw new RuntimeException("Arbitrary Failure");
@@ -294,8 +194,7 @@ class AwsSecretsManagerTest {
               return new AbstractMap.SimpleEntry<>(name, value);
             });
 
-    validateMappedSecret(secretEntries, secretNames.get(0));
-
+    validateMappedSecret(secretEntries, allTestSecretTags);
     final Optional<AbstractMap.SimpleEntry<String, String>> failEntry =
         secretEntries.stream().filter(e -> e.getKey().equals(failEntryName)).findAny();
     assertThat(failEntry).isEmpty();
@@ -303,14 +202,12 @@ class AwsSecretsManagerTest {
 
   @Test
   void throwsAwayObjectsWhichMapToNull() {
-    createSecret(true, false, false);
-
-    final String nullEntryName = secretNames.get(1);
+    final String nullEntryName = testSecretNames.get(1);
 
     Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
-            secretTags.keySet().stream().collect(Collectors.toList()),
-            secretTags.values().stream().collect(Collectors.toList()),
+            allTestSecretTags.keySet(),
+            allTestSecretTags.values(),
             (name, value) -> {
               if (name.equals(nullEntryName)) {
                 return null;
@@ -318,14 +215,11 @@ class AwsSecretsManagerTest {
               return new AbstractMap.SimpleEntry<>(name, value);
             });
 
-    validateMappedSecret(secretEntries, secretNames.get(0));
-
+    validateMappedSecret(secretEntries, allTestSecretTags);
     final Optional<AbstractMap.SimpleEntry<String, String>> nullEntry =
         secretEntries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
     assertThat(nullEntry).isEmpty();
   }
-<<<<<<< HEAD
-=======
 
   private static void initAwsSecretsManagers() {
     awsSecretsManagerDefault = AwsSecretsManager.createAwsSecretsManager();
@@ -467,9 +361,13 @@ class AwsSecretsManagerTest {
       final Map<String, String> testTags) {
     testTags.keySet().stream()
         .filter(tagKey -> testSecretNames.contains(tagKey))
-        .forEach(tagKey ->
-            assertThat(tagKey).isIn(secretEntries.stream().map(e -> e.getKey()))
-        );
+        .collect(Collectors.toList())
+        .forEach(
+            tagKey ->
+                assertThat(tagKey)
+                    .isIn(
+                        secretEntries.stream()
+                            .map(entry -> entry.getKey())
+                            .collect(Collectors.toList())));
   }
->>>>>>> e917f7a... Update keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
 }

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -64,7 +64,6 @@ class AwsSecretsManagerTest {
   private String secretName2WithTagKey1ValB;
   private String secretName3WithTagKey2ValC;
   private String secretName4WithTagKey2ValB;
-  private String secretName5WithEmptyValue;
 
   void verifyEnvironmentVariables() {
     Assumptions.assumeTrue(
@@ -121,7 +120,6 @@ class AwsSecretsManagerTest {
     assertThat(secret).isEmpty();
   }
 
-  // emptyTagFiltersReturnAllKeys: search([], []) returns all secrets
   @Test
   void emptyTagFiltersReturnAllSecrets() {
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
@@ -155,7 +153,6 @@ class AwsSecretsManagerTest {
     assertThat(secretNames).isEmpty();
   }
 
-  // secretsWithMatchingKeysAreReturned: search([k1], []) returns [secret1, secret2]
   @Test
   void listAndMapSecretsWithMatchingTagKeys() {
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
@@ -176,7 +173,6 @@ class AwsSecretsManagerTest {
     assertThat(secretValues).contains(SECRET_VALUE);
   }
 
-  // secretsWithMatchingValuesAreReturned: search([], [vB, vC]) returns [secret2, secret3, secret4]
   @Test
   void listAndMapSecretsWithMatchingTagValues() {
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
@@ -193,7 +189,6 @@ class AwsSecretsManagerTest {
         .doesNotContain(secretName1WithTagKey1ValA);
   }
 
-  // secretsWithMatchingKeysOrValuesAreReturned: search([k1], [vB]) returns [secret2]
   @Test
   void listAndMapSecretsWithMatchingTagKeysAndValues() {
 

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -126,11 +125,7 @@ class AwsSecretsManagerTest {
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), Collections.emptyList(), AbstractMap.SimpleEntry::new);
 
-    final List<String> secretNames =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getKey()))
-            .collect(Collectors.toList());
-    assertThat(secretNames)
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
         .contains(
             secretName1WithTagKey1ValA,
             secretName2WithTagKey1ValB,
@@ -146,11 +141,7 @@ class AwsSecretsManagerTest {
             List.of("nonexistent-tag-value"),
             AbstractMap.SimpleEntry::new);
 
-    final List<String> secretNames =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getKey()))
-            .collect(Collectors.toList());
-    assertThat(secretNames).isEmpty();
+    assertThat(secretEntries).isEmpty();
   }
 
   @Test
@@ -159,18 +150,10 @@ class AwsSecretsManagerTest {
         awsSecretsManagerExplicit.mapSecrets(
             List.of("tagKey1"), Collections.emptyList(), AbstractMap.SimpleEntry::new);
 
-    final List<String> secretNames =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getKey()))
-            .collect(Collectors.toList());
-    final List<String> secretValues =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getValue()))
-            .collect(Collectors.toList());
-    assertThat(secretNames)
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
         .contains(secretName1WithTagKey1ValA, secretName2WithTagKey1ValB)
         .doesNotContain(secretName3WithTagKey2ValC, secretName4WithTagKey2ValB);
-    assertThat(secretValues).contains(SECRET_VALUE);
+    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
   }
 
   @Test
@@ -179,31 +162,24 @@ class AwsSecretsManagerTest {
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), List.of("tagValB", "tagValC"), AbstractMap.SimpleEntry::new);
 
-    final List<String> secretNames =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getKey()))
-            .collect(Collectors.toList());
-    assertThat(secretNames)
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
         .contains(
             secretName2WithTagKey1ValB, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB)
         .doesNotContain(secretName1WithTagKey1ValA);
+    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
   }
 
   @Test
   void listAndMapSecretsWithMatchingTagKeysAndValues() {
-
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(
             List.of("tagKey1"), List.of("tagValB"), AbstractMap.SimpleEntry::new);
 
-    final List<String> secretNames =
-        secretEntries.stream()
-            .map(entry -> String.valueOf(entry.getKey()))
-            .collect(Collectors.toList());
-    assertThat(secretNames)
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
         .contains(secretName2WithTagKey1ValB)
         .doesNotContain(
             secretName1WithTagKey1ValA, secretName3WithTagKey2ValC, secretName4WithTagKey2ValB);
+    assertThat(secretEntries.stream().map(e -> e.getValue())).contains(SECRET_VALUE);
   }
 
   @Test
@@ -219,9 +195,8 @@ class AwsSecretsManagerTest {
               return new AbstractMap.SimpleEntry<>(name, value);
             });
 
-    final Optional<AbstractMap.SimpleEntry<String, String>> nullEntry =
-        secretEntries.stream().filter(e -> e.getKey().equals(secretName1WithTagKey1ValA)).findAny();
-    assertThat(nullEntry).isEmpty();
+    assertThat(secretEntries.stream().map(e -> e.getKey()))
+        .doesNotContain(secretName1WithTagKey1ValA);
   }
 
   private void initAwsSecretsManagers() {
@@ -262,7 +237,7 @@ class AwsSecretsManagerTest {
 
   private String createSecret(final Tag tag)
       throws ExecutionException, InterruptedException, TimeoutException {
-    final String testSecretName = SECRET_NAME_PREFIX + "/" + UUID.randomUUID();
+    final String testSecretName = SECRET_NAME_PREFIX + UUID.randomUUID();
 
     final CreateSecretRequest secretRequest =
         CreateSecretRequest.builder()

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -121,6 +121,26 @@ class AwsSecretsManagerTest {
   }
 
   @Test
+  void listAndMapSecretsWithMatchingKeysAreReturned() {
+
+  }
+
+  @Test
+  void secretsWithMatchingValuesAreReturned() {
+
+  }
+
+  @Test
+  void secretsWithMatchingKeysOrValuesAreReturned() {
+
+  }
+
+  @Test
+  void emptyTagFiltersReturnAllKeys() {
+
+  }
+
+  @Test
   void listAndMapSingleSecretWithSingleTag() {
     final Collection<AbstractMap.SimpleEntry<String, String>> secretEntries =
         awsSecretsManagerExplicit.mapSecrets(

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -121,24 +121,16 @@ class AwsSecretsManagerTest {
   }
 
   @Test
-  void listAndMapSecretsWithMatchingKeysAreReturned() {
-
-  }
+  void listAndMapSecretsWithMatchingKeysAreReturned() {}
 
   @Test
-  void secretsWithMatchingValuesAreReturned() {
-
-  }
+  void secretsWithMatchingValuesAreReturned() {}
 
   @Test
-  void secretsWithMatchingKeysOrValuesAreReturned() {
-
-  }
+  void secretsWithMatchingKeysOrValuesAreReturned() {}
 
   @Test
-  void emptyTagFiltersReturnAllKeys() {
-
-  }
+  void emptyTagFiltersReturnAllKeys() {}
 
   @Test
   void listAndMapSingleSecretWithSingleTag() {

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -240,7 +240,7 @@ class AwsSecretsManagerTest {
         AwsBasicCredentials.create(RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
     credentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
     testSecretsManagerClient =
-          SecretsManagerAsyncClient.builder()
+        SecretsManagerAsyncClient.builder()
             .credentialsProvider(credentialsProvider)
             .region(Region.of(AWS_REGION))
             .build();
@@ -271,8 +271,9 @@ class AwsSecretsManagerTest {
   }
 
   private static void waitUntilSecretAvailable(final String secretName) {
-    testSecretsManagerClient.getSecretValue(
-        GetSecretValueRequest.builder().secretId(secretName).build()).join();
+    testSecretsManagerClient
+        .getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build())
+        .join();
   }
 
   private static void createSecret(final boolean multipleTags, final boolean sharedTags) {


### PR DESCRIPTION
Fixed keystorage aws test failures + refactoring. AWS Secrets Managers are now initialized and closed, before and after each test case respectively to avoid race conditions when creating and deleting secrets.

Related to https://github.com/ConsenSys/web3signer/issues/499