### PR TITLE
Include AWS STS library so that web identity tokens can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+### Bugs Fixed
+ - AWS secrets manager using environment config didn't work when using web identity tokens due to missing sts library.
+
 ## 2.2.1
 ### Features Added
  - Update various dependent libraries versions

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -93,6 +93,7 @@ dependencyManagement {
       entry 'bom'
       entry 'auth'
       entry 'secretsmanager'
+      entry 'sts'
     }
   }
 }

--- a/keystorage/aws/build.gradle
+++ b/keystorage/aws/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   implementation 'software.amazon.awssdk:secretsmanager'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
+  runtimeOnly 'software.amazon.awssdk:sts'
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine'


### PR DESCRIPTION
Include AWS STS library so that web identity tokens can be used. It's not on the class path by default.

There is a note here that the STS library is required on the classpath https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.html