### PR TITLE
Add gradle dependency check plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,20 @@ commands:
           name: Gather test results
           when: always
           command: |
-            FILES=`find . -name reports`
+            FILES=`find . -name reports -not -path './build/reports'`
             for FILE in $FILES
             do
               MODULE=`echo "$FILE" | sed -e 's@./\(.*\)/build/reports@\1@'`
               TARGET="build/test-reports/$MODULE"
+              SOURCE="${FILE}/tests/test"
               mkdir -p "$TARGET"
-              cp -rf ${FILE}/*/* "$TARGET"
+              if [[ -d "$SOURCE" ]]; then
+                  cp -rf "$SOURCE" "$TARGET"
+              fi
             done
+            if [[ -f 'build/reports/dependency-check-report.html' ]]; then
+              cp 'build/reports/dependency-check-report.html' 'build/test-reports'
+            fi
       - store_artifacts:
           path: build/test-reports
           destination: test-reports
@@ -93,6 +99,10 @@ jobs:
           name: Build
           command: |
             ./gradlew --no-daemon --parallel build
+      - run:
+          name: Dependency vulnerability scan
+          command: |
+            ./gradlew --no-daemon dependencyCheckAggregate
       - run:
           name: Test
           no_output_timeout: 20m

--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,8 @@ allprojects {
     failBuildOnCVSS = 4 // Fail on medium CVSS severity
     suppressionFile = "${rootDir}/gradle/owasp-suppression.xml"
     skipConfigurations = [
-            'integrationTestCompileClasspath',
-            'integrationTestRuntimeClasspath'
+      'integrationTestCompileClasspath',
+      'integrationTestRuntimeClasspath'
     ]
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
   dependencies {
     // custom written license renderer used by com.github.jk1.dependency-license-report
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
+    classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
   }
 }
 
@@ -93,6 +94,7 @@ allprojects {
   apply plugin: 'jacoco'
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'distribution'
+  apply plugin: 'org.owasp.dependencycheck'
   apply from: "${rootDir}/gradle/versions.gradle"
 
   version = rootProject.version
@@ -145,6 +147,15 @@ allprojects {
       target '**/*.groovy'
       licenseHeaderFile "${rootDir}/gradle/spotless.java.license", 'import'
     }
+  }
+
+  dependencyCheck {
+    failBuildOnCVSS = 4 // Fail on medium CVSS severity
+    suppressionFile = "${rootDir}/gradle/owasp-suppression.xml"
+    skipConfigurations = [
+            'integrationTestCompileClasspath',
+            'integrationTestRuntimeClasspath'
+    ]
   }
 
   tasks.withType(JavaCompile) {

--- a/gradle/owasp-suppression.xml
+++ b/gradle/owasp-suppression.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -98,15 +98,15 @@ dependencyManagement {
 
     // explicit declaring to override transitive dependencies with vulnerabilities
     // addressing CVE-2022-24823
-//    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
-//      entry 'netty-codec-http2'
-//      entry 'netty-handler-proxy'
-//      entry 'netty-resolver-dns'
-//      entry 'netty-resolver-dns-native-macos'
-//      entry 'netty-transport-native-epoll'
-//      entry 'netty-transport-native-kqueue'
-//      entry 'netty-transport-native-unix-common'
-//      entry 'netty-transport-classes-epoll'
-//    }
+    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
+      entry 'netty-codec-http2'
+      entry 'netty-handler-proxy'
+      entry 'netty-resolver-dns'
+      entry 'netty-resolver-dns-native-macos'
+      entry 'netty-transport-native-epoll'
+      entry 'netty-transport-native-kqueue'
+      entry 'netty-transport-native-unix-common'
+      entry 'netty-transport-classes-epoll'
+    }
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -98,15 +98,15 @@ dependencyManagement {
 
     // explicit declaring to override transitive dependencies with vulnerabilities
     // addressing CVE-2022-24823
-    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
-      entry 'netty-codec-http2'
-      entry 'netty-handler-proxy'
-      entry 'netty-resolver-dns'
-      entry 'netty-resolver-dns-native-macos'
-      entry 'netty-transport-native-epoll'
-      entry 'netty-transport-native-kqueue'
-      entry 'netty-transport-native-unix-common'
-      entry 'netty-transport-classes-epoll'
-    }
+//    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
+//      entry 'netty-codec-http2'
+//      entry 'netty-handler-proxy'
+//      entry 'netty-resolver-dns'
+//      entry 'netty-resolver-dns-native-macos'
+//      entry 'netty-transport-native-epoll'
+//      entry 'netty-transport-native-kqueue'
+//      entry 'netty-transport-native-unix-common'
+//      entry 'netty-transport-classes-epoll'
+//    }
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -23,7 +23,7 @@ dependencyManagement {
     }
     dependency 'com.google.guava:guava:31.1-jre'
 
-    dependencySet(group: 'com.azure', version: '4.3.8') {
+    dependencySet(group: 'com.azure', version: '4.4.2') {
       entry 'azure-security-keyvault-secrets'
       entry 'azure-security-keyvault-keys'
     }
@@ -35,7 +35,7 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.4.0'
 
-    dependencySet(group: 'io.vertx', version: '4.2.6') {
+    dependencySet(group: 'io.vertx', version: '4.2.7') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'
@@ -94,6 +94,19 @@ dependencyManagement {
       entry 'auth'
       entry 'secretsmanager'
       entry 'sts'
+    }
+
+    // explicit declaring to override transitive dependencies with vulnerabilities
+    // addressing CVE-2022-24823
+    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
+      entry 'netty-codec-http2'
+      entry 'netty-handler-proxy'
+      entry 'netty-resolver-dns'
+      entry 'netty-resolver-dns-native-macos'
+      entry 'netty-transport-native-epoll'
+      entry 'netty-transport-native-kqueue'
+      entry 'netty-transport-native-unix-common'
+      entry 'netty-transport-classes-epoll'
     }
   }
 }


### PR DESCRIPTION
Same config as ethsigner and web3signer.

Fix CVE-2022-24823 by locking in netty version 4.1.77

Couple of relevant upgrades.