### PR TITLE
Update to jackson-databind to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
   dependencies {
     // custom written license renderer used by com.github.jk1.dependency-license-report
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
+    classpath 'org.owasp:dependency-check-gradle:7.2.1'
   }
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1'
 
     dependencySet(group: 'com.google.errorprone', version: '2.11.0') {
       entry 'error_prone_annotation'


### PR DESCRIPTION
Update jackson-databind library to 2.14.0-rc1 to address [CVE-2022-42003](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42003) and [CVE-2022-42004](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42004)