### PR TITLE
Upgrade dependency-check-gradle plugin to 7.4.4 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
   dependencies {
     // custom written license renderer used by com.github.jk1.dependency-license-report
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:7.4.1'
+    classpath 'org.owasp:dependency-check-gradle:7.4.4'
   }
 }
 


### PR DESCRIPTION
Fixes CVE-2020-36569 database exception see https://github.com/jeremylong/DependencyCheck/issues/5220