### PR TITLE
AWS secrets manager results enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.2.8
+- AWS/Azure Secret mapping results reporting error count. This can be used as part of healthcheck service.
+
 ## 2.2.7
 - Update Azure SDK versions
 --- 

--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -139,9 +139,12 @@ public class AwsSecretsManager implements Closeable {
                               LOG.warn(
                                   "Failed to fetch secret name '{}', and was discarded",
                                   secretEntry.name());
+                              errorCount.incrementAndGet();
                             } else {
-                              result.addAll(
-                                  mapSecretValue(mapper, secretEntry.name(), secretValue.get()));
+                              SecretValueResult<R> multiResult =
+                                  mapSecretValue(mapper, secretEntry.name(), secretValue.get());
+                              result.addAll(multiResult.getValues());
+                              errorCount.addAndGet(multiResult.getErrorCount());
                             }
                           } catch (final Exception e) {
                             LOG.warn(

--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -83,6 +83,13 @@ public class AwsSecretsManager implements Closeable {
     return new AwsSecretsManager(secretsManagerClient);
   }
 
+  /**
+   * Fetch single secret using name.
+   *
+   * @param secretName Secret Name
+   * @return Optional with secret value. Empty if secret name doesn't exist.
+   * @throws RuntimeException if AWS SDK throws SecretsManagerException.
+   */
   public Optional<String> fetchSecret(final String secretName) {
     try {
       final GetSecretValueRequest getSecretValueRequest =
@@ -116,6 +123,15 @@ public class AwsSecretsManager implements Closeable {
         listSecretsRequestBuilder.filters(filters).build());
   }
 
+  /**
+   * Bulk load secrets.
+   *
+   * @param namePrefixes Collection of name prefixes to filter.
+   * @param tagKeys Collection of tags names to filter
+   * @param tagValues Collection of tag values to filter
+   * @param mapper The mapper function that can convert secret value to appropriate type
+   * @return SecretValueResult with collection of secret values and error count if any.
+   */
   public <R> SecretValueResult<R> mapSecrets(
       final Collection<String> namePrefixes,
       final Collection<String> tagKeys,

--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -14,7 +14,7 @@ package tech.pegasys.signers.aws;
 
 import static tech.pegasys.signers.common.SecretValueMapperUtil.mapSecretValue;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 
 import java.io.Closeable;
 import java.net.URI;
@@ -132,7 +132,7 @@ public class AwsSecretsManager implements Closeable {
    * @param mapper The mapper function that can convert secret value to appropriate type
    * @return SecretValueResult with collection of secret values and error count if any.
    */
-  public <R> SecretValueResult<R> mapSecrets(
+  public <R> MappedResults<R> mapSecrets(
       final Collection<String> namePrefixes,
       final Collection<String> tagKeys,
       final Collection<String> tagValues,
@@ -157,7 +157,7 @@ public class AwsSecretsManager implements Closeable {
                                     secretEntry.name());
                                 errorCount.incrementAndGet();
                               } else {
-                                SecretValueResult<R> multiResult =
+                                MappedResults<R> multiResult =
                                     mapSecretValue(mapper, secretEntry.name(), secretValue.get());
                                 result.addAll(multiResult.getValues());
                                 errorCount.addAndGet(multiResult.getErrorCount());
@@ -174,7 +174,7 @@ public class AwsSecretsManager implements Closeable {
       LOG.warn("Unexpected error during AWS list-secrets operation", e);
       errorCount.incrementAndGet();
     }
-    return SecretValueResult.newInstance(result, errorCount.intValue());
+    return MappedResults.newInstance(result, errorCount.intValue());
   }
 
   @Override

--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManagerProvider.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManagerProvider.java
@@ -13,6 +13,8 @@
 package tech.pegasys.signers.aws;
 
 import java.io.Closeable;
+import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -43,19 +45,24 @@ public class AwsSecretsManagerProvider implements Closeable {
   }
 
   public AwsSecretsManager createAwsSecretsManager(
-      final String accessKeyId, final String secretAccessKey, final String region) {
+      final String accessKeyId,
+      final String secretAccessKey,
+      final String region,
+      final Optional<URI> awsEndpointOverride) {
     return fromCacheOrCallable(
         new AwsKeyIdentifier(accessKeyId, Region.of(region)),
-        () -> AwsSecretsManager.createAwsSecretsManager(accessKeyId, secretAccessKey, region));
+        () ->
+            AwsSecretsManager.createAwsSecretsManager(
+                accessKeyId, secretAccessKey, region, awsEndpointOverride));
   }
 
-  public AwsSecretsManager createAwsSecretsManager() {
+  public AwsSecretsManager createAwsSecretsManager(final Optional<URI> awsEndpointOverride) {
     final String accessKeyId =
         DefaultCredentialsProvider.create().resolveCredentials().accessKeyId();
     final Region region = DefaultAwsRegionProviderChain.builder().build().getRegion();
     return fromCacheOrCallable(
         new AwsKeyIdentifier(accessKeyId, region),
-        () -> AwsSecretsManager.createAwsSecretsManager());
+        () -> AwsSecretsManager.createAwsSecretsManager(awsEndpointOverride));
   }
 
   @Override

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerProviderTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerProviderTest.java
@@ -14,6 +14,7 @@ package tech.pegasys.signers.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URI;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -53,30 +54,42 @@ class AwsSecretsManagerProviderTest {
   private final String DIFFERENT_AWS_SECRET_ACCESS_KEY = System.getenv("RW_AWS_SECRET_ACCESS_KEY");
   private final String DIFFERENT_AWS_REGION = "us-east-1";
 
+  // can be pointed to localstack
+  private final Optional<URI> awsEndpointOverride =
+      System.getenv("AWS_ENDPOINT_OVERRIDE") != null
+          ? Optional.of(URI.create(System.getenv("AWS_ENDPOINT_OVERRIDE")))
+          : Optional.empty();
+
   private AwsSecretsManagerProvider awsSecretsManagerProvider;
 
   private AwsSecretsManager createDefaultSecretsManager() {
-    return awsSecretsManagerProvider.createAwsSecretsManager();
+    return awsSecretsManagerProvider.createAwsSecretsManager(awsEndpointOverride);
   }
 
   private AwsSecretsManager createSpecifiedSecretsManager() {
     return awsSecretsManagerProvider.createAwsSecretsManager(
-        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION);
+        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, awsEndpointOverride);
   }
 
   private AwsSecretsManager createSecretsManagerDifferentKeys() {
     return awsSecretsManagerProvider.createAwsSecretsManager(
-        DIFFERENT_AWS_ACCESS_KEY_ID, DIFFERENT_AWS_SECRET_ACCESS_KEY, AWS_REGION);
+        DIFFERENT_AWS_ACCESS_KEY_ID,
+        DIFFERENT_AWS_SECRET_ACCESS_KEY,
+        AWS_REGION,
+        awsEndpointOverride);
   }
 
   private AwsSecretsManager createSecretsManagerDifferentRegion() {
     return awsSecretsManagerProvider.createAwsSecretsManager(
-        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, DIFFERENT_AWS_REGION);
+        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, DIFFERENT_AWS_REGION, awsEndpointOverride);
   }
 
   private AwsSecretsManager createSecretsManagerDifferentKeysDifferentRegion() {
     return awsSecretsManagerProvider.createAwsSecretsManager(
-        DIFFERENT_AWS_ACCESS_KEY_ID, DIFFERENT_AWS_SECRET_ACCESS_KEY, DIFFERENT_AWS_REGION);
+        DIFFERENT_AWS_ACCESS_KEY_ID,
+        DIFFERENT_AWS_SECRET_ACCESS_KEY,
+        DIFFERENT_AWS_REGION,
+        awsEndpointOverride);
   }
 
   @BeforeEach

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -95,7 +95,6 @@ class AwsSecretsManagerTest {
 
   @BeforeAll
   void setup() {
-    System.out.println("*** " + awsEndpointOverride.get());
     initAwsSecretsManagers();
     initTestSecretsManagerClient();
     createTestSecrets();
@@ -400,12 +399,26 @@ class AwsSecretsManagerTest {
     assertThat(secretValueResult.getErrorCount()).isEqualTo(1);
   }
 
-  private void initAwsSecretsManagers() {
+  @Test
+  void mapSecretsWithInvalidCredentialsReturnsError() {
+    SecretValueResult<SimpleEntry<String, String>> result =
+        awsSecretsManagerInvalidCredentials.mapSecrets(
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            SimpleEntry::new);
 
+    assertThat(result.getErrorCount()).isOne();
+    assertThat(result.getValues()).isEmpty();
+  }
+
+  private void initAwsSecretsManagers() {
     awsSecretsManagerDefault = AwsSecretsManager.createAwsSecretsManager(awsEndpointOverride);
     awsSecretsManagerExplicit =
         AwsSecretsManager.createAwsSecretsManager(
             RO_AWS_ACCESS_KEY_ID, RO_AWS_SECRET_ACCESS_KEY, AWS_REGION, awsEndpointOverride);
+
+    // don't override endpoint for invalid credentials as localstack doesn't perform authentication
     awsSecretsManagerInvalidCredentials =
         AwsSecretsManager.createAwsSecretsManager(
             "invalid", "invalid", AWS_REGION, Optional.empty());

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -16,8 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tech.pegasys.signers.aws.SecretsMaps.SECRET_NAME_PREFIX_A;
 
+import tech.pegasys.signers.common.SecretValueResult;
+
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -146,7 +147,7 @@ class AwsSecretsManagerTest {
 
   @Test
   void emptyFiltersReturnAllSecrets() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -154,50 +155,50 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     assertThat(fetchedKeys).containsAll(secretsMaps.getAllSecretsMap().keySet());
   }
 
   @Test
   void nonExistentTagFiltersReturnsEmpty() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             List.of("nonexistent-tag-key"),
             List.of("nonexistent-tag-value"),
             SimpleEntry::new);
 
-    assertThat(secretEntries).isEmpty();
+    assertThat(secretValueResult.getValues()).isEmpty();
   }
 
   @Test
   void nonExistentPrefixFilterReturnsEmpty() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             List.of("nonexistent-secret-prefix"),
             Collections.emptyList(),
             Collections.emptyList(),
             SimpleEntry::new);
 
-    assertThat(secretEntries).isEmpty();
+    assertThat(secretValueResult.getValues()).isEmpty();
   }
 
   @Test
   void nonExistentPrefixFilterWithTagFilterReturnsEmpty() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             List.of("nonexistent-secret-prefix"),
             List.of("tagKey1"),
             Collections.emptyList(),
             SimpleEntry::new);
 
-    assertThat(secretEntries).isEmpty();
+    assertThat(secretValueResult.getValues()).isEmpty();
   }
 
   @Test
   void listAndMapSecretsWithPrefix() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             List.of(SECRET_NAME_PREFIX_A),
             Collections.emptyList(),
@@ -205,7 +206,7 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     assertThat(fetchedKeys).containsAll(secretsMaps.getPrefixASecretsMap().keySet());
     assertThat(fetchedKeys)
@@ -214,7 +215,7 @@ class AwsSecretsManagerTest {
 
   @Test
   void listAndMapSecretsWithPrefixAndTags() {
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             List.of(SECRET_NAME_PREFIX_A),
             List.of("tagKey1"),
@@ -222,7 +223,7 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getPrefixASecretsMap().entrySet().stream()
@@ -247,12 +248,13 @@ class AwsSecretsManagerTest {
   @Test
   void listAndMapSecretsWithMatchingTagKeys() {
     final Set<String> expectedTagKeys = Set.of("tagKey1");
-    final Collection<SimpleEntry<String, String>> secretEntries =
+
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), expectedTagKeys, Collections.emptyList(), SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getAllSecretsMap().entrySet().stream()
@@ -276,11 +278,11 @@ class AwsSecretsManagerTest {
   void listAndMapSecretsWithMatchingTagValues() {
     final Set<String> expectedTagValues = Set.of("tagValB", "tagValC");
 
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), Collections.emptyList(), expectedTagValues, SimpleEntry::new);
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     // expected tag values from both maps should have returned
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
@@ -306,11 +308,11 @@ class AwsSecretsManagerTest {
     final Set<String> expectedTagKeys = Set.of("tagKey1");
     final Set<String> expectedTagValues = Set.of("tagValB");
 
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), expectedTagKeys, expectedTagValues, SimpleEntry::new);
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getAllSecretsMap().entrySet().stream()
@@ -337,7 +339,7 @@ class AwsSecretsManagerTest {
     final Map<String, AwsSecret> secretsMap = secretsMaps.getAllSecretsMap();
     final String expectedKey = secretsMap.keySet().stream().findAny().orElseThrow();
 
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -349,7 +351,7 @@ class AwsSecretsManagerTest {
               return new SimpleEntry<>(name, value);
             });
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Set<String> expectedKeys =
         secretsMap.keySet().stream()
@@ -364,7 +366,7 @@ class AwsSecretsManagerTest {
   void throwsAwayObjectsThatFailMapper() {
     final Map<String, AwsSecret> secretsMap = secretsMaps.getAllSecretsMap();
     final String expectedKey = secretsMap.keySet().stream().findAny().orElseThrow();
-    final Collection<SimpleEntry<String, String>> secretEntries =
+    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -377,7 +379,7 @@ class AwsSecretsManagerTest {
             });
 
     final Set<String> fetchedKeys =
-        secretEntries.stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Set<String> expectedKeys =
         secretsMap.keySet().stream()
@@ -386,6 +388,7 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
+    assertThat(secretValueResult.getExceptions()).isNotEmpty();
   }
 
   private void initAwsSecretsManagers() {

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tech.pegasys.signers.aws.SecretsMaps.SECRET_NAME_PREFIX_A;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 
 import java.net.URI;
 import java.util.AbstractMap.SimpleEntry;
@@ -155,7 +155,7 @@ class AwsSecretsManagerTest {
 
   @Test
   void emptyFiltersReturnAllSecrets() {
-    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    final MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -163,50 +163,50 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     assertThat(fetchedKeys).containsAll(secretsMaps.getAllSecretsMap().keySet());
   }
 
   @Test
   void nonExistentTagFiltersReturnsEmpty() {
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             List.of("nonexistent-tag-key"),
             List.of("nonexistent-tag-value"),
             SimpleEntry::new);
 
-    assertThat(secretValueResult.getValues()).isEmpty();
+    assertThat(mappedResults.getValues()).isEmpty();
   }
 
   @Test
   void nonExistentPrefixFilterReturnsEmpty() {
-    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    final MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             List.of("nonexistent-secret-prefix"),
             Collections.emptyList(),
             Collections.emptyList(),
             SimpleEntry::new);
 
-    assertThat(secretValueResult.getValues()).isEmpty();
+    assertThat(mappedResults.getValues()).isEmpty();
   }
 
   @Test
   void nonExistentPrefixFilterWithTagFilterReturnsEmpty() {
-    final SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    final MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             List.of("nonexistent-secret-prefix"),
             List.of("tagKey1"),
             Collections.emptyList(),
             SimpleEntry::new);
 
-    assertThat(secretValueResult.getValues()).isEmpty();
+    assertThat(mappedResults.getValues()).isEmpty();
   }
 
   @Test
   void listAndMapSecretsWithPrefix() {
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             List.of(SECRET_NAME_PREFIX_A),
             Collections.emptyList(),
@@ -214,7 +214,7 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     assertThat(fetchedKeys).containsAll(secretsMaps.getPrefixASecretsMap().keySet());
     assertThat(fetchedKeys)
@@ -223,7 +223,7 @@ class AwsSecretsManagerTest {
 
   @Test
   void listAndMapSecretsWithPrefixAndTags() {
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             List.of(SECRET_NAME_PREFIX_A),
             List.of("tagKey1"),
@@ -231,7 +231,7 @@ class AwsSecretsManagerTest {
             SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getPrefixASecretsMap().entrySet().stream()
@@ -257,12 +257,12 @@ class AwsSecretsManagerTest {
   void listAndMapSecretsWithMatchingTagKeys() {
     final Set<String> expectedTagKeys = Set.of("tagKey1");
 
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), expectedTagKeys, Collections.emptyList(), SimpleEntry::new);
 
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getAllSecretsMap().entrySet().stream()
@@ -286,11 +286,11 @@ class AwsSecretsManagerTest {
   void listAndMapSecretsWithMatchingTagValues() {
     final Set<String> expectedTagValues = Set.of("tagValB", "tagValC");
 
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), Collections.emptyList(), expectedTagValues, SimpleEntry::new);
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     // expected tag values from both maps should have returned
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
@@ -316,11 +316,11 @@ class AwsSecretsManagerTest {
     final Set<String> expectedTagKeys = Set.of("tagKey1");
     final Set<String> expectedTagValues = Set.of("tagValB");
 
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(), expectedTagKeys, expectedTagValues, SimpleEntry::new);
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Map<Boolean, List<Map.Entry<String, AwsSecret>>> expectedSecrets =
         secretsMaps.getAllSecretsMap().entrySet().stream()
@@ -347,7 +347,7 @@ class AwsSecretsManagerTest {
     final Map<String, AwsSecret> secretsMap = secretsMaps.getAllSecretsMap();
     final String expectedKey = secretsMap.keySet().stream().findAny().orElseThrow();
 
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -359,7 +359,7 @@ class AwsSecretsManagerTest {
               return new SimpleEntry<>(name, value);
             });
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Set<String> expectedKeys =
         secretsMap.keySet().stream()
@@ -374,7 +374,7 @@ class AwsSecretsManagerTest {
   void throwsAwayObjectsThatFailMapper() {
     final Map<String, AwsSecret> secretsMap = secretsMaps.getAllSecretsMap();
     final String expectedKey = secretsMap.keySet().stream().findAny().orElseThrow();
-    SecretValueResult<SimpleEntry<String, String>> secretValueResult =
+    MappedResults<SimpleEntry<String, String>> mappedResults =
         awsSecretsManagerExplicit.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),
@@ -387,7 +387,7 @@ class AwsSecretsManagerTest {
             });
 
     final Set<String> fetchedKeys =
-        secretValueResult.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
+        mappedResults.getValues().stream().map(SimpleEntry::getKey).collect(Collectors.toSet());
 
     final Set<String> expectedKeys =
         secretsMap.keySet().stream()
@@ -396,12 +396,12 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
-    assertThat(secretValueResult.getErrorCount()).isEqualTo(1);
+    assertThat(mappedResults.getErrorCount()).isEqualTo(1);
   }
 
   @Test
   void mapSecretsWithInvalidCredentialsReturnsError() {
-    SecretValueResult<SimpleEntry<String, String>> result =
+    MappedResults<SimpleEntry<String, String>> result =
         awsSecretsManagerInvalidCredentials.mapSecrets(
             Collections.emptyList(),
             Collections.emptyList(),

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -397,7 +397,7 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
-    assertThat(secretValueResult.getErrorCount()).isGreaterThan(0);
+    assertThat(secretValueResult.getErrorCount()).isEqualTo(1);
   }
 
   private void initAwsSecretsManagers() {

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -388,7 +388,7 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
-    assertThat(secretValueResult.getExceptions()).isNotEmpty();
+    assertThat(secretValueResult.getErrorCount()).isGreaterThan(0);
   }
 
   private void initAwsSecretsManagers() {

--- a/keystorage/azure/build.gradle
+++ b/keystorage/azure/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation 'com.azure:azure-security-keyvault-secrets'
   implementation 'com.azure:azure-security-keyvault-keys'
   implementation 'com.azure:azure-identity'
+  implementation project(':keystorage:common')
 
   runtimeOnly 'org.apache.logging.log4j:log4j-core'
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
+++ b/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.signers.azure;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 
 import java.util.List;
 import java.util.Optional;
@@ -108,7 +108,7 @@ public class AzureKeyVault {
         .collect(Collectors.toList());
   }
 
-  public <R> SecretValueResult<R> mapSecrets(final BiFunction<String, String, R> mapper) {
+  public <R> MappedResults<R> mapSecrets(final BiFunction<String, String, R> mapper) {
     final Set<R> result = ConcurrentHashMap.newKeySet();
     final AtomicInteger errorCount = new AtomicInteger(0);
     try {
@@ -147,6 +147,6 @@ public class AzureKeyVault {
       LOG.error("Unexpected error during Azure map-secrets", e);
       errorCount.incrementAndGet();
     }
-    return SecretValueResult.newInstance(result, errorCount.intValue());
+    return MappedResults.newInstance(result, errorCount.intValue());
   }
 }

--- a/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
+++ b/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
@@ -12,11 +12,13 @@
  */
 package tech.pegasys.signers.azure;
 
-import java.util.Collection;
+import tech.pegasys.signers.common.SecretValueResult;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -106,41 +108,45 @@ public class AzureKeyVault {
         .collect(Collectors.toList());
   }
 
-  public <R> Collection<R> mapSecrets(final BiFunction<String, String, R> mapper) {
-    final PagedIterable<SecretProperties> secretsPagedIterable;
-    try {
-      secretsPagedIterable = secretClient.listPropertiesOfSecrets();
-    } catch (final Exception e) {
-      throw new RuntimeException(
-          "Failed to connect to an Azure Keyvault with provided configuration.", e);
-    }
-
+  public <R> SecretValueResult<R> mapSecrets(final BiFunction<String, String, R> mapper) {
     final Set<R> result = ConcurrentHashMap.newKeySet();
-    secretsPagedIterable
-        .streamByPage()
-        .forEach(
-            keyPage ->
-                keyPage
-                    .getValue()
-                    .parallelStream()
-                    .forEach(
-                        sp -> {
-                          try {
-                            final KeyVaultSecret secret = secretClient.getSecret(sp.getName());
-                            final R obj = mapper.apply(sp.getName(), secret.getValue());
-                            if (obj != null) {
-                              result.add(obj);
-                            } else {
-                              LOG.warn(
-                                  "Mapped '{}' to a null object, and was discarded", sp.getName());
-                            }
-                          } catch (final Exception e) {
-                            LOG.warn(
-                                "Failed to map secret '{}' to requested object type.",
-                                sp.getName());
-                          }
-                        }));
+    final AtomicInteger errorCount = new AtomicInteger(0);
+    try {
+      final PagedIterable<SecretProperties> secretsPagedIterable =
+          secretClient.listPropertiesOfSecrets();
 
-    return result;
+      secretsPagedIterable
+          .streamByPage()
+          .forEach(
+              keyPage ->
+                  keyPage
+                      .getValue()
+                      .parallelStream()
+                      .forEach(
+                          sp -> {
+                            try {
+                              final KeyVaultSecret secret = secretClient.getSecret(sp.getName());
+                              final R obj = mapper.apply(sp.getName(), secret.getValue());
+                              if (obj != null) {
+                                result.add(obj);
+                              } else {
+                                LOG.warn(
+                                    "Mapped '{}' to a null object, and was discarded",
+                                    sp.getName());
+                                errorCount.incrementAndGet();
+                              }
+                            } catch (final Exception e) {
+                              LOG.warn(
+                                  "Failed to map secret '{}' to requested object type.",
+                                  sp.getName());
+                              errorCount.incrementAndGet();
+                            }
+                          }));
+
+    } catch (final Exception e) {
+      LOG.error("Unexpected error during Azure map-secrets", e);
+      errorCount.incrementAndGet();
+    }
+    return new SecretValueResult<>(result, errorCount.intValue());
   }
 }

--- a/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
+++ b/keystorage/azure/src/main/java/tech/pegasys/signers/azure/AzureKeyVault.java
@@ -147,6 +147,6 @@ public class AzureKeyVault {
       LOG.error("Unexpected error during Azure map-secrets", e);
       errorCount.incrementAndGet();
     }
-    return new SecretValueResult<>(result, errorCount.intValue());
+    return SecretValueResult.newInstance(result, errorCount.intValue());
   }
 }

--- a/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
+++ b/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tech.pegasys.signers.azure.AzureKeyVault.createUsingClientSecretCredentials;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
@@ -90,7 +90,7 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    final SecretValueResult<SimpleEntry<String, String>> result =
+    final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(SimpleEntry::new);
     final Collection<SimpleEntry<String, String>> entries = result.getValues();
     final Optional<SimpleEntry<String, String>> myBlsEntry =
@@ -109,7 +109,7 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    final SecretValueResult<SimpleEntry<String, String>> result =
+    final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
             (name, value) -> {
               if (name.equals("MyBls")) {
@@ -134,7 +134,7 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    final SecretValueResult<SimpleEntry<String, String>> result =
+    final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
             (name, value) -> {
               if (name.equals("TEST-KEY")) {

--- a/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
+++ b/keystorage/azure/src/test/java/tech/pegasys/signers/azure/AzureKeyVaultTest.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tech.pegasys.signers.azure.AzureKeyVault.createUsingClientSecretCredentials;
 
+import tech.pegasys.signers.common.SecretValueResult;
+
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Optional;
@@ -88,8 +90,9 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    Collection<SimpleEntry<String, String>> entries = azureKeyVault.mapSecrets(SimpleEntry::new);
-
+    final SecretValueResult<SimpleEntry<String, String>> result =
+        azureKeyVault.mapSecrets(SimpleEntry::new);
+    final Collection<SimpleEntry<String, String>> entries = result.getValues();
     final Optional<SimpleEntry<String, String>> myBlsEntry =
         entries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
     assertThat(myBlsEntry).isPresent();
@@ -106,7 +109,7 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    Collection<SimpleEntry<String, String>> entries =
+    final SecretValueResult<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
             (name, value) -> {
               if (name.equals("MyBls")) {
@@ -114,6 +117,7 @@ public class AzureKeyVaultTest {
               }
               return new SimpleEntry<>(name, value);
             });
+    final Collection<SimpleEntry<String, String>> entries = result.getValues();
 
     final Optional<SimpleEntry<String, String>> testKeyEntry =
         entries.stream().filter(e -> e.getKey().equals("TEST-KEY")).findAny();
@@ -130,7 +134,7 @@ public class AzureKeyVaultTest {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME);
 
-    Collection<SimpleEntry<String, String>> entries =
+    final SecretValueResult<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
             (name, value) -> {
               if (name.equals("TEST-KEY")) {
@@ -138,6 +142,7 @@ public class AzureKeyVaultTest {
               }
               return new SimpleEntry<>(name, value);
             });
+    final Collection<SimpleEntry<String, String>> entries = result.getValues();
     final Optional<SimpleEntry<String, String>> testKeyEntry =
         entries.stream().filter(e -> e.getKey().equals("TEST-KEY")).findAny();
     assertThat(testKeyEntry).isEmpty();

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/MappedResults.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/MappedResults.java
@@ -37,13 +37,12 @@ public class MappedResults<R> {
     return new MappedResults<>(new HashSet<>(), 0);
   }
 
-  public static <R> MappedResults<R> newInstance(
-      final Collection<R> values, final int errorCount) {
+  public static <R> MappedResults<R> newInstance(final Collection<R> values, final int errorCount) {
     return new MappedResults<>(values, errorCount);
   }
 
   public static <R> MappedResults<R> merge(
-          final MappedResults<R> first, final MappedResults<R> second) {
+      final MappedResults<R> first, final MappedResults<R> second) {
     final List<R> combinedList =
         Stream.concat(first.values.stream(), second.values.stream()).collect(Collectors.toList());
     final int errorCount = first.errorCount + second.errorCount;

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/MappedResults.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/MappedResults.java
@@ -20,34 +20,34 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** Contains Collection of Secret value result and count of errors. */
-public class SecretValueResult<R> {
+public class MappedResults<R> {
   private final Collection<R> values;
   private int errorCount;
 
-  SecretValueResult(final Collection<R> values, final int errorCount) {
+  MappedResults(final Collection<R> values, final int errorCount) {
     this.values = values;
     this.errorCount = errorCount;
   }
 
-  public static <R> SecretValueResult<R> errorResult() {
-    return new SecretValueResult<>(Collections.emptyList(), 1);
+  public static <R> MappedResults<R> errorResult() {
+    return new MappedResults<>(Collections.emptyList(), 1);
   }
 
-  public static <R> SecretValueResult<R> newSetInstance() {
-    return new SecretValueResult<>(new HashSet<>(), 0);
+  public static <R> MappedResults<R> newSetInstance() {
+    return new MappedResults<>(new HashSet<>(), 0);
   }
 
-  public static <R> SecretValueResult<R> newInstance(
+  public static <R> MappedResults<R> newInstance(
       final Collection<R> values, final int errorCount) {
-    return new SecretValueResult<>(values, errorCount);
+    return new MappedResults<>(values, errorCount);
   }
 
-  public static <R> SecretValueResult<R> merge(
-      final SecretValueResult<R> first, final SecretValueResult<R> second) {
+  public static <R> MappedResults<R> merge(
+          final MappedResults<R> first, final MappedResults<R> second) {
     final List<R> combinedList =
         Stream.concat(first.values.stream(), second.values.stream()).collect(Collectors.toList());
     final int errorCount = first.errorCount + second.errorCount;
-    return new SecretValueResult<>(combinedList, errorCount);
+    return new MappedResults<>(combinedList, errorCount);
   }
 
   public void mergeErrorCount(final int otherErrorCount) {

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueMapperUtil.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueMapperUtil.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
 public class SecretValueMapperUtil {
   private static final Logger LOG = LogManager.getLogger();
 
-  public static <R> SecretValueResult<R> mapSecretValue(
+  public static <R> MappedResults<R> mapSecretValue(
       BiFunction<String, String, R> mapper, String secretName, String secretValue) {
     final AtomicInteger errorCount = new AtomicInteger(0);
     final Set<R> result =
@@ -44,6 +44,6 @@ public class SecretValueMapperUtil {
                 })
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
-    return SecretValueResult.newInstance(result, errorCount.intValue());
+    return MappedResults.newInstance(result, errorCount.intValue());
   }
 }

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueMapperUtil.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueMapperUtil.java
@@ -44,6 +44,6 @@ public class SecretValueMapperUtil {
                 })
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
-    return new SecretValueResult<>(result, errorCount.intValue());
+    return SecretValueResult.newInstance(result, errorCount.intValue());
   }
 }

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
@@ -13,17 +13,30 @@
 package tech.pegasys.signers.common;
 
 import java.util.Collection;
+import java.util.Collections;
 
-/**
- * Contains Collection of Secret value result and collection of exceptions which may have raised.
- */
+/** Contains Collection of Secret value result and count of errors. */
 public class SecretValueResult<R> {
   private final Collection<R> values;
-  private final int errorCount;
+  private int errorCount;
 
-  public SecretValueResult(final Collection<R> values, final int errorCount) {
+  SecretValueResult(final Collection<R> values, final int errorCount) {
     this.values = values;
     this.errorCount = errorCount;
+  }
+
+  public static <R> SecretValueResult<R> errorResult() {
+    return new SecretValueResult<>(Collections.emptyList(), 1);
+  }
+
+  public static <R> SecretValueResult<R> newInstance(
+      final Collection<R> values, final int errorCount) {
+    return new SecretValueResult<>(values, errorCount);
+  }
+
+  public void merge(final SecretValueResult<R> other) {
+    this.values.addAll(other.values);
+    this.errorCount += other.errorCount;
   }
 
   public Collection<R> getValues() {

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signers.common;
+
+import java.util.Collection;
+
+/**
+ * Contains Collection of Secret value result and collection of exceptions which may have raised.
+ */
+public class SecretValueResult<R> {
+  private final Collection<R> values;
+  private final Collection<Exception> exceptions;
+
+  public SecretValueResult(final Collection<R> values, final Collection<Exception> exceptions) {
+    this.values = values;
+    this.exceptions = exceptions;
+  }
+
+  public Collection<R> getValues() {
+    return values;
+  }
+
+  public Collection<Exception> getExceptions() {
+    return exceptions;
+  }
+}

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
@@ -39,6 +39,10 @@ public class SecretValueResult<R> {
     this.errorCount += other.errorCount;
   }
 
+  public void mergeErrorCount(final int otherErrorCount) {
+    this.errorCount += otherErrorCount;
+  }
+
   public Collection<R> getValues() {
     return values;
   }

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
@@ -14,6 +14,10 @@ package tech.pegasys.signers.common;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** Contains Collection of Secret value result and count of errors. */
 public class SecretValueResult<R> {
@@ -29,14 +33,21 @@ public class SecretValueResult<R> {
     return new SecretValueResult<>(Collections.emptyList(), 1);
   }
 
+  public static <R> SecretValueResult<R> newSetInstance() {
+    return new SecretValueResult<>(new HashSet<>(), 0);
+  }
+
   public static <R> SecretValueResult<R> newInstance(
       final Collection<R> values, final int errorCount) {
     return new SecretValueResult<>(values, errorCount);
   }
 
-  public void merge(final SecretValueResult<R> other) {
-    this.values.addAll(other.values);
-    this.errorCount += other.errorCount;
+  public static <R> SecretValueResult<R> merge(
+      final SecretValueResult<R> first, final SecretValueResult<R> second) {
+    final List<R> combinedList =
+        Stream.concat(first.values.stream(), second.values.stream()).collect(Collectors.toList());
+    final int errorCount = first.errorCount + second.errorCount;
+    return new SecretValueResult<>(combinedList, errorCount);
   }
 
   public void mergeErrorCount(final int otherErrorCount) {

--- a/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
+++ b/keystorage/common/src/main/java/tech/pegasys/signers/common/SecretValueResult.java
@@ -19,18 +19,18 @@ import java.util.Collection;
  */
 public class SecretValueResult<R> {
   private final Collection<R> values;
-  private final Collection<Exception> exceptions;
+  private final int errorCount;
 
-  public SecretValueResult(final Collection<R> values, final Collection<Exception> exceptions) {
+  public SecretValueResult(final Collection<R> values, final int errorCount) {
     this.values = values;
-    this.exceptions = exceptions;
+    this.errorCount = errorCount;
   }
 
   public Collection<R> getValues() {
     return values;
   }
 
-  public Collection<Exception> getExceptions() {
-    return exceptions;
+  public int getErrorCount() {
+    return errorCount;
   }
 }

--- a/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
+++ b/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
@@ -57,7 +57,7 @@ class SecretValueMapperUtilTest {
 
   @Test
   void nullMappedIsNotReturned() {
-    SecretValueResult<String> result =
+    MappedResults<String> result =
         mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {
@@ -81,7 +81,7 @@ class SecretValueMapperUtilTest {
 
   @Test
   void sameValuesAreMappedOnce() {
-    SecretValueResult<String> result =
+    MappedResults<String> result =
         mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {

--- a/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
+++ b/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
@@ -34,10 +34,12 @@ class SecretValueMapperUtilTest {
 
   @Test
   void newlinesValuesAreMapped() {
-    Collection<String> mappedValues = mapSecretValue((k, v) -> v, "key", "value1\nvalue2").getValues();
+    Collection<String> mappedValues =
+        mapSecretValue((k, v) -> v, "key", "value1\nvalue2").getValues();
     assertThat(mappedValues).containsOnly("value1", "value2");
 
-    Collection<String> mappedValues2 = mapSecretValue((k, v) -> v, "key", "value1\nvalue2\n").getValues();
+    Collection<String> mappedValues2 =
+        mapSecretValue((k, v) -> v, "key", "value1\nvalue2\n").getValues();
     assertThat(mappedValues2).containsOnly("value1", "value2");
   }
 
@@ -55,7 +57,8 @@ class SecretValueMapperUtilTest {
 
   @Test
   void nullMappedIsNotReturned() {
-    SecretValueResult<String> result = mapSecretValue(
+    SecretValueResult<String> result =
+        mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {
                 return null;
@@ -78,7 +81,8 @@ class SecretValueMapperUtilTest {
 
   @Test
   void sameValuesAreMappedOnce() {
-    SecretValueResult<String> result = mapSecretValue(
+    SecretValueResult<String> result =
+        mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {
                 return null;
@@ -87,8 +91,7 @@ class SecretValueMapperUtilTest {
             },
             "key",
             "ok\nerr1\nerr2\nok\nok1");
-    Collection<String> mappedValues =
-        result.getValues();
+    Collection<String> mappedValues = result.getValues();
 
     assertThat(mappedValues).containsOnly("ok", "ok1");
     assertThat(result.getErrorCount()).isEqualTo(2);

--- a/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
+++ b/keystorage/common/src/test/java/tech/pegasys/signers/common/SecretValueMapperUtilTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.signers.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.signers.common.SecretValueMapperUtil.mapSecretValue;
 
-import java.util.Set;
+import java.util.Collection;
 
 import de.neuland.assertj.logging.ExpectedLogging;
 import de.neuland.assertj.logging.ExpectedLoggingAssertions;
@@ -28,35 +28,34 @@ class SecretValueMapperUtilTest {
 
   @Test
   void singleValueIsMapped() {
-    Set<String> mappedValues = mapSecretValue((k, v) -> v, "key", "value");
+    Collection<String> mappedValues = mapSecretValue((k, v) -> v, "key", "value").getValues();
     assertThat(mappedValues).containsOnly("value");
   }
 
   @Test
   void newlinesValuesAreMapped() {
-    Set<String> mappedValues = mapSecretValue((k, v) -> v, "key", "value1\nvalue2");
+    Collection<String> mappedValues = mapSecretValue((k, v) -> v, "key", "value1\nvalue2").getValues();
     assertThat(mappedValues).containsOnly("value1", "value2");
 
-    Set<String> mappedValues2 = mapSecretValue((k, v) -> v, "key", "value1\nvalue2\n");
+    Collection<String> mappedValues2 = mapSecretValue((k, v) -> v, "key", "value1\nvalue2\n").getValues();
     assertThat(mappedValues2).containsOnly("value1", "value2");
   }
 
   @Test
   void emptyStringResultsEmptyCollection() {
-    Set<String> mappedValues = mapSecretValue((k, v) -> v, "key", "");
+    Collection<String> mappedValues = mapSecretValue((k, v) -> v, "key", "").getValues();
     assertThat(mappedValues).isEmpty();
   }
 
   @Test
   void emptyLineTerminationsReturnsEmptyStrings() {
-    assertThat(mapSecretValue((k, v) -> v, "key", "\n")).containsOnly("");
-    assertThat(mapSecretValue((k, v) -> v, "key", "\nok\n\n")).containsOnly("", "ok");
+    assertThat(mapSecretValue((k, v) -> v, "key", "\n").getValues()).containsOnly("");
+    assertThat(mapSecretValue((k, v) -> v, "key", "\nok\n\n").getValues()).containsOnly("", "ok");
   }
 
   @Test
   void nullMappedIsNotReturned() {
-    Set<String> mappedValues =
-        mapSecretValue(
+    SecretValueResult<String> result = mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {
                 return null;
@@ -65,6 +64,7 @@ class SecretValueMapperUtilTest {
             },
             "0xabc",
             "ok1\nerr1\nerr2\nok2");
+    Collection<String> mappedValues = result.getValues();
 
     assertThat(mappedValues).containsOnly("ok1", "ok2");
 
@@ -72,12 +72,13 @@ class SecretValueMapperUtilTest {
         .hasWarningMessage("Value from secret name 0xabc at index 1 was not mapped and discarded.");
     ExpectedLoggingAssertions.assertThat(logging)
         .hasWarningMessage("Value from secret name 0xabc at index 2 was not mapped and discarded.");
+
+    assertThat(result.getErrorCount()).isEqualTo(2);
   }
 
   @Test
   void sameValuesAreMappedOnce() {
-    Set<String> mappedValues =
-        mapSecretValue(
+    SecretValueResult<String> result = mapSecretValue(
             (k, v) -> {
               if (v.startsWith("err")) {
                 return null;
@@ -86,7 +87,10 @@ class SecretValueMapperUtilTest {
             },
             "key",
             "ok\nerr1\nerr2\nok\nok1");
+    Collection<String> mappedValues =
+        result.getValues();
 
     assertThat(mappedValues).containsOnly("ok", "ok1");
+    assertThat(result.getErrorCount()).isEqualTo(2);
   }
 }


### PR DESCRIPTION
AWS secrets manager results enhancements 
-- Return any exceptions raised during sercrets manager operation.
-- The presence of these exceptions can be used for healthcheck status

Part of fixing: https://github.com/ConsenSys/web3signer/issues/715

Sample healthcheck:
```
{
  "status": "DOWN",
  "checks": [
    {
      "id": "default-check",
      "status": "UP"
    },
    {
      "id": "keys-check",
      "status": "DOWN",
      "checks": [
        {
          "id": "azure-bulk-loading",
          "status": "DOWN",
          "data": {
            "keys-loaded": 0,
            "error-count": 1
          }
        }
      ]
    }
  ],
  "outcome": "DOWN"
}
```