### PR TITLE
Fix AWS Acceptance test assertion

### DIFF
--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -100,7 +100,7 @@ public class AwsSecretsManager implements Closeable {
     } catch (final ResourceNotFoundException e) {
       return Optional.empty();
     } catch (final SecretsManagerException e) {
-      throw new RuntimeException("Failed to fetch secret from AWS Secrets Manager.", e);
+      throw new RuntimeException("Failed to fetch secret from AWS Secrets Manager: " + e.getMessage(), e);
     }
   }
 

--- a/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
+++ b/keystorage/aws/src/main/java/tech/pegasys/signers/aws/AwsSecretsManager.java
@@ -100,7 +100,8 @@ public class AwsSecretsManager implements Closeable {
     } catch (final ResourceNotFoundException e) {
       return Optional.empty();
     } catch (final SecretsManagerException e) {
-      throw new RuntimeException("Failed to fetch secret from AWS Secrets Manager: " + e.getMessage(), e);
+      throw new RuntimeException(
+          "Failed to fetch secret from AWS Secrets Manager: " + e.getMessage(), e);
     }
   }
 

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
@@ -397,7 +396,8 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
-    // we don't know the exact error count since this test is loading all the secrets from our live secret manager and
+    // we don't know the exact error count since this test is loading all the secrets from our live
+    // secret manager and
     // some values fails to load due to read-only user doesn't have authentication on them.
     assertThat(mappedResults.getErrorCount()).isGreaterThanOrEqualTo(1);
   }

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -144,7 +144,7 @@ class AwsSecretsManagerTest {
     final String key = secretsMap.keySet().stream().findAny().orElseThrow();
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> awsSecretsManagerInvalidCredentials.fetchSecret(key))
-        .withMessageContaining("Failed to fetch secret from AWS Secrets Manager.");
+        .withMessageContaining("Failed to fetch secret from AWS Secrets Manager");
   }
 
   @Test

--- a/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
+++ b/keystorage/aws/src/test/java/tech/pegasys/signers/aws/AwsSecretsManagerTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
@@ -396,7 +397,9 @@ class AwsSecretsManagerTest {
 
     assertThat(fetchedKeys).containsAll(expectedKeys);
     assertThat(fetchedKeys).doesNotContain(expectedKey);
-    assertThat(mappedResults.getErrorCount()).isEqualTo(1);
+    // we don't know the exact error count since this test is loading all the secrets from our live secret manager and
+    // some values fails to load due to read-only user doesn't have authentication on them.
+    assertThat(mappedResults.getErrorCount()).isGreaterThanOrEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
Fix AWS Acceptance test assertion. Since CI runs the test against live AWS secrets manager, some of the keys return fails due to authentication error. Hence fix the errorCount to not assert on fix number.